### PR TITLE
Add simple model with time path solution

### DIFF
--- a/DeBacker_Evans_simple/README.md
+++ b/DeBacker_Evans_simple/README.md
@@ -1,0 +1,18 @@
+# Code for Chapter 7: "S-period-lived Agents with Endogenous Labor"
+
+This folder contains the code to solve the model presented in Chapter 7, "S-period-lived Agents with Endogenous Labor" of the textbook, *Overlapping Generations Models for Policy Analysis: Theory and Computation*. The files needed to run the model are the following five Python scripts and modules:
+
+* `execute.py`
+* `SS.py`
+* `TPI.py`
+* `households.py`
+* `firms.py`
+* `aggregates.py`
+* `elliputil.py`
+* `utilities.py`
+
+This code was writen using the [Anaconda distribution](https://www.continuum.io/downloads) of Python 3.5.2. The folders `images` and `OUTPUT` will be created (overwritten) in the course of running your script. The `images` folder will contain the images created in the process of running your code, both steady-state and transition path equilibria. The `OUTPUT` folder will contain the Python objects as well as underlying parameters (pickle .pkl files) from the steady-state and transition path equilibria.
+
+Before running your computation of the model solution, you should open the file `execute.py` and adjust the parameters of the model. The main parameters are in lines 84-113 of `execute.py`. You may also want to update the assumption of the Frisch elasticity of labor supply in line 139 or the assumed initial distribution of savings (wealth) for the transition path solution in lines 289-294. The model can be run by navigating in your terminal to the folder where you have cloned your fork of this repository. Navigate to the `OGtextbook/Python/Chap7/` folder and type `python execute.py`.
+
+For the current baseline parameterization of the model with eighty-period-lived individuals (`S=80`), the steady-state solution takes between 26 seconds and 2 minutes depending on which solution method you use. However, the transition path solution takes just over 4.3 hours to run (88 time path iterations). The transition path solution can be sped up tremendously by parallelizing its computation.

--- a/DeBacker_Evans_simple/SS.py
+++ b/DeBacker_Evans_simple/SS.py
@@ -1,0 +1,432 @@
+'''
+------------------------------------------------------------------------
+This module contains the functions used to solve the steady state of
+the model with S-period lived agents and endogenous labor supply from
+Chapter 4 of the OG textbook.
+
+This Python module imports the following module(s):
+    households.py
+    firms.py
+    aggregates.py
+    utilities.py
+
+This Python module defines the following function(s):
+    inner_loop()
+    get_SS()
+    create_graphs()
+------------------------------------------------------------------------
+'''
+# Import packages
+import time
+import numpy as np
+import scipy.optimize as opt
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+import os
+import households as hh
+import firms
+import aggregates as aggr
+import utilities as utils
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def euler_sys(guesses, *args):
+    '''
+    --------------------------------------------------------------------
+    Specify the system of Euler Equations characterizing the household
+    problem.
+    --------------------------------------------------------------------
+    INPUTS:
+    guesses = (2S-1,) vector, guess at labor supply and savings decisions
+    args = length 14 tuple, (r, w, beta, sigma, l_tilde, chi_n_vec,
+            b_ellip, upsilon, diff, S, SS_tol)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        hh.get_n_errors()
+        hh.get_n_errors()
+        hh.get_cons()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    r    = scalar > 0, guess at steady-state interest rate
+    w    = scalar > 0, guess at steady-state wage
+    beta       = scalar in (0,1), discount factor
+    sigma      = scalar >= 1, coefficient of relative risk aversion
+    l_tilde    = scalar > 0, per-period time endowment for every agent
+    chi_n_vec  = (S,) vector, values for chi^n_s
+    b_ellip    = scalar > 0, fitted value of b for elliptical disutility
+                 of labor
+    upsilon    = scalar > 1, fitted value of upsilon for elliptical
+                 disutility of labor
+    A          = scalar > 0, total factor productivity parameter in
+                 firms' production function
+    diff    = boolean, =True if simple difference Euler errors,
+                 otherwise percent deviation Euler errors
+    S          = integer >= 3, number of periods in individual lifetime
+    SS_tol     = scalar > 0, tolerance level for steady-state fsolve
+    nvec       = (S,) vector, lifetime labor supply (n1, n2, ...nS)
+    bvec       = (S,) vector, lifetime savings (b1, b2, ...bS) with b1=0
+    cvec       = (S,) vector, lifetime consumption (c1, c2, ...cS)
+    b_sp1      = = (S,) vector, lifetime savings (b1, b2, ...bS) with bS=0
+    n_errors   = (S,) vector, labor supply Euler errors
+    b_errors   = (S-1,) vector, savings Euler errors
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: array of n_errors and b_errors
+    --------------------------------------------------------------------
+    '''
+    (r, w, beta, sigma, l_tilde, chi_n_vec, b_ellip, upsilon, diff, S,
+     SS_tol) = args
+    nvec = guesses[:S]
+    bvec1 = guesses[S:]
+
+    bvec = np.append(0.0, bvec1)
+    b_sp1 = np.append(bvec[1:], 0.0)
+    cvec = hh.get_cons(r, w, bvec, b_sp1, nvec)
+    n_args = (w, sigma, l_tilde, chi_n_vec, b_ellip, upsilon, diff,
+              cvec)
+    n_errors = hh.get_n_errors(nvec, *n_args)
+    b_args = (r, beta, sigma, diff)
+    b_errors = hh.get_b_errors(cvec, *b_args)
+
+    errors = np.append(n_errors, b_errors)
+
+    return errors
+
+
+def inner_loop(r, w, args):
+    '''
+    --------------------------------------------------------------------
+    Given values for r and w, solve for the households' optimal decisions
+    --------------------------------------------------------------------
+    INPUTS:
+    r    = scalar > 0, guess at steady-state interest rate
+    w    = scalar > 0, guess at steady-state wage
+    args = length 14 tuple, (nvec_init, bvec_init, S, beta, sigma,
+            l_tilde, b_ellip, upsilon, chi_n_vec, A, alpha, delta,
+            EulDiff, SS_tol)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        euler_sys()
+        aggr.get_K()
+        aggr.get_L()
+        firms.get_r()
+        firms.get_w()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    nvec_init  = (S,) vector, initial guesses at choice of labor supply
+    bvec_init  = (S,) vector, initial guesses at choice of savings
+    S          = integer >= 3, number of periods in individual lifetime
+    beta       = scalar in (0,1), discount factor
+    sigma      = scalar >= 1, coefficient of relative risk aversion
+    l_tilde    = scalar > 0, per-period time endowment for every agent
+    b_ellip    = scalar > 0, fitted value of b for elliptical disutility
+                 of labor
+    upsilon    = scalar > 1, fitted value of upsilon for elliptical
+                 disutility of labor
+    chi_n_vec  = (S,) vector, values for chi^n_s
+    A          = scalar > 0, total factor productivity parameter in
+                 firms' production function
+    alpha      = scalar in (0,1), capital share of income
+    delta      = scalar in [0,1], model-period depreciation rate of
+                 capital
+    EulDiff    = boolean, =True if simple difference Euler errors,
+                 otherwise percent deviation Euler errors
+    SS_tol     = scalar > 0, tolerance level for steady-state fsolve
+    cvec       = (S,) vector, lifetime consumption (c1, c2, ...cS)
+    nvec       = (S,) vector, lifetime labor supply (n1, n2, ...nS)
+    bvec       = (S,) vector, lifetime savings (b1, b2, ...bS) with b1=0
+    b_Sp1      = scalar, final period savings, should be close to zero
+    n_errors   = (S,) vector, labor supply Euler errors
+    b_errors   = (S-1,) vector, savings Euler errors
+    K          = scalar > 0, aggregate capital stock
+    K_cstr     = boolean, =True if K < epsilon
+    L          = scalar > 0, aggregate labor
+    L_cstr     = boolean, =True if L < epsilon
+    r_params   = length 3 tuple, (A, alpha, delta)
+    w_params   = length 2 tuple, (A, alpha)
+    r_new      = scalar > 0, guess at steady-state interest rate
+    w_new      = scalar > 0, guess at steady-state wage
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: K, L, cvec, nvec, bvec, b_Sp1, r_new, w_new, n_errors,
+             b_errors
+    --------------------------------------------------------------------
+    '''
+    (nvec_init, bvec_init, S, beta, sigma, l_tilde, b_ellip, upsilon,
+     chi_n_vec, A, alpha, delta, EulDiff, SS_tol) = args
+
+    euler_args = (r, w, beta, sigma, l_tilde, chi_n_vec, b_ellip,
+                  upsilon, EulDiff, S, SS_tol)
+    guesses = np.append(nvec_init, bvec_init[1:])
+    results_euler = opt.root(euler_sys, guesses, args=(euler_args),
+                             method='lm', tol=SS_tol)
+    nvec = results_euler.x[:S]
+    bvec = np.append(0.0, results_euler.x[S:])
+    n_errors = results_euler.fun[:S]
+    b_errors = results_euler.fun[S:]
+    b_sp1 = np.append(bvec[1:], 0.0)
+    cvec = hh.get_cons(r, w, bvec, b_sp1, nvec)
+    b_Sp1 = 0.0
+    K, K_cstr = aggr.get_K(bvec)
+    L, L_cstr = aggr.get_L(nvec)
+    r_params = (A, alpha, delta)
+    r_new = firms.get_r(K, L, r_params)
+    w_params = (A, alpha, delta)
+    w_new = firms.get_w(r_new, w_params)
+
+    return (K, L, cvec, nvec, bvec, b_Sp1, r_new, w_new, n_errors,
+            b_errors)
+
+
+def get_SS(init_vals, args, graphs=False):
+    '''
+    --------------------------------------------------------------------
+    Solve for the steady-state solution of the S-period-lived agent OG
+    model with endogenous labor supply using the bisection method in K
+    and L for the outer loop
+    --------------------------------------------------------------------
+    INPUTS:
+    init_vals = length 2 tuple, (rss_init, c1_init)
+    args      = length 15 tuple, (S, beta, sigma, l_tilde, b_ellip,
+                upsilon, chi_n_vec, A, alpha, delta, Bsct_Tol, Eul_Tol,
+                EulDiff, xi, maxiter)
+    graphs    = boolean, =True if output steady-state graphs
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        firms.get_r()
+        firms.get_w()
+        utils.print_time()
+        inner_loop()
+        creat_graphs()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    start_time = scalar > 0, clock time at beginning of program
+    r_init     = scalar > -delta, initial guess for steady-state
+                 interest rate
+    c1_init    = scalar > 0, initial guess for first period consumpt'n
+    S          = integer in [3, 80], number of periods an individual
+                 lives
+    beta       = scalar in (0,1), discount factor for each model per
+    sigma      = scalar > 0, coefficient of relative risk aversion
+    l_tilde    = scalar > 0, time endowment for each agent each period
+    b_ellip    = scalar > 0, fitted value of b for elliptical disutility
+                 of labor
+    upsilon    = scalar > 1, fitted value of upsilon for elliptical
+                 disutility of labor
+    chi_n_vec  = (S,) vector, values for chi^n_s
+    A          = scalar > 0, total factor productivity parameter in
+                 firms' production function
+    alpha      = scalar in (0,1), capital share of income
+    delta      = scalar in [0,1], model-period depreciation rate of
+                 capital
+    Bsct_Tol   = scalar > 0, tolderance level for outer-loop bisection
+                 method
+    Eul_Tol    = scalar > 0, tolerance level for inner-loop root finder
+    EulDiff    = Boolean, =True if want difference version of Euler
+                 errors beta*(1+r)*u'(c2) - u'(c1), =False if want
+                 ratio version [beta*(1+r)*u'(c2)]/[u'(c1)] - 1
+    xi         = scalar in (0, 1], SS updating parameter in outer-loop
+                 bisection method
+    maxiter    = integer >= 1, maximum number of iterations in outer
+                 loop bisection method
+    iter_SS    = integer >= 0, index of iteration number
+    dist       = scalar > 0, distance metric for current iteration
+    rw_params  = length 3 tuple, (A, alpha, delta) args to pass into
+                 firms.get_r() and firms.get_w()
+    w_init     = scalar, initial value for wage
+    inner_args = length 14 tuple, args to pass into inner_loop()
+    K_new      = scalar > 0, updated K given r_init, w_init, and bvec
+    L_new      = scalar > 0, updated L given r_init, w_init, and nvec
+    cvec       = (S,) vector, updated values for lifetime consumption
+    nvec       = (S,) vector, updated values for lifetime labor supply
+    bvec       = (S,) vector, updated values for lifetime savings
+                 (b1, b2,...bS)
+    b_Sp1      = scalar, updated value for savings in last period,
+                 should be arbitrarily close to zero
+    r_new      = scalar > 0, updated interest rate given bvec and nvec
+    w_new      = scalar > 0, updated wage given bvec and nvec
+    n_errors   = (S,) vector, labor supply Euler errors given r_init
+                 and w_init
+    b_errors   = (S-1,) vector, savings Euler errors given r_init and
+                 w_init
+    all_errors = (2S,) vector, (n_errors, b_errors, b_Sp1)
+    c_ss       = (S,) vector, steady-state lifetime consumption
+    n_ss       = (S,) vector, steady-state lifetime labor supply
+    b_ss       = (S,) vector, steady-state wealth enter period with
+                 (b1, b2, ...bS)
+    b_Sp1_ss   = scalar, steady-state savings for period after last
+                 period of life. b_Sp1_ss approx. 0 in equilibrium
+    n_err_ss   = (S,) vector, lifetime labor supply Euler errors
+    b_err_ss   = (S-1) vector, lifetime savings Euler errors
+    r_ss       = scalar > 0, steady-state interest rate
+    w_ss       = scalar > 0, steady-state wage
+    K_ss       = scalar > 0, steady-state aggregate capital stock
+    L_ss       = scalar > 0, steady-state aggregate labor
+    Y_params   = length 2 tuple, (A, alpha)
+    Y_ss       = scalar > 0, steady-state aggregate output (GDP)
+    C_ss       = scalar > 0, steady-state aggregate consumption
+    RCerr_ss   = scalar, resource constraint error
+    ss_time    = scalar, seconds elapsed for steady-state computation
+    ss_output  = length 14 dict, steady-state objects {n_ss, b_ss,
+                 c_ss, b_Sp1_ss, w_ss, r_ss, K_ss, L_ss, Y_ss, C_ss,
+                 n_err_ss, b_err_ss, RCerr_ss, ss_time}
+
+    FILES CREATED BY THIS FUNCTION:
+        SS_bc.png
+        SS_n.png
+
+    RETURNS: ss_output
+    --------------------------------------------------------------------
+    '''
+    start_time = time.clock()
+    r_init, c1_init = init_vals
+    (S, beta, sigma, l_tilde, b_ellip, upsilon, chi_n_vec, A, alpha,
+     delta, Bsct_Tol, Eul_Tol, EulDiff, xi, maxiter) = args
+    iter_SS = 0
+    dist = 10
+    nvec_init = np.ones(S) * 0.4
+    bvec_init = np.append(0.0, np.ones(S - 1) * 0.05)
+    rw_params = (A, alpha, delta)
+    while (iter_SS < maxiter) and (dist >= Bsct_Tol):
+        iter_SS += 1
+        w_init = firms.get_w(r_init, rw_params)
+        inner_args = (nvec_init, bvec_init, S, beta, sigma, l_tilde,
+                      b_ellip, upsilon, chi_n_vec, A, alpha, delta,
+                      EulDiff, Eul_Tol)
+        (K_new, L_new, cvec, nvec, bvec, b_Sp1, r_new, w_new, n_errors,
+            b_errors) = inner_loop(r_init, w_init, inner_args)
+        all_errors = np.hstack((n_errors, b_errors, b_Sp1))
+        dist = (np.absolute(r_new - r_init)).sum()
+        r_init = xi * r_new + (1 - xi) * r_init
+        print('SS Iter=', iter_SS, ', SS Dist=', '%10.4e' % (dist),
+              ', Max Abs Err=', '%10.4e' %
+              (np.absolute(all_errors).max()))
+
+    c_ss = cvec
+    n_ss = nvec
+    b_ss = bvec
+    b_Sp1_ss = b_Sp1
+    n_err_ss = n_errors
+    b_err_ss = b_errors
+    r_ss = r_new
+    w_ss = w_new
+    K_ss = K_new
+    L_ss = L_new
+    Y_params = (A, alpha)
+    Y_ss = aggr.get_Y(K_ss, L_ss, Y_params)
+    C_ss = aggr.get_C(c_ss)
+    RCerr_ss = Y_ss - C_ss - delta * K_ss
+
+    ss_time = time.clock() - start_time
+
+    ss_output = {
+        'c_ss': c_ss, 'n_ss': n_ss, 'b_ss': b_ss, 'b_Sp1_ss': b_Sp1_ss,
+        'w_ss': w_ss, 'r_ss': r_ss, 'K_ss': K_ss, 'L_ss': L_ss,
+        'Y_ss': Y_ss, 'C_ss': C_ss, 'n_err_ss': n_err_ss,
+        'b_err_ss': b_err_ss, 'RCerr_ss': RCerr_ss, 'ss_time': ss_time}
+    print('n_ss is: ', n_ss)
+    print('b_ss is: ', b_ss)
+    print('K_ss=', K_ss, ', L_ss=', L_ss)
+    print('r_ss=', r_ss, ', w_ss=', w_ss)
+    print('Maximum abs. labor supply Euler error is: ',
+          np.absolute(n_err_ss).max())
+    print('Maximum abs. savings Euler error is: ',
+          np.absolute(b_err_ss).max())
+    print('Resource constraint error is: ', RCerr_ss)
+    print('Steady-state residual savings b_Sp1 is: ', b_Sp1_ss)
+
+    # Print SS computation time
+    utils.print_time(ss_time, 'SS')
+
+    if graphs:
+        create_graphs(c_ss, b_ss, n_ss)
+
+    return ss_output
+
+
+def create_graphs(c_ss, b_ss, n_ss):
+    '''
+    --------------------------------------------------------------------
+    Plot steady-state equilibrium results
+    --------------------------------------------------------------------
+    INPUTS:
+    c_ss = (S,) vector, steady-state lifetime consumption
+    b_ss = (S,) vector, steady-state lifetime savings (b1, b2, ...bS)
+           where b1 = 0
+    n_ss = (S,) vector, steady-state lifetime labor supply
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    cur_path    = string, path name of current directory
+    output_fldr = string, folder in current path to save files
+    output_dir  = string, total path of images folder
+    output_path = string, path of file name of figure to be saved
+    S           = integer in [3, 80], number of periods an individual
+                  lives
+    b_ss_full   = (S+1,) vector, b_ss with zero appended on end.
+                  (b1, b2, ...bS, bSp1) where b1, bSp1 = 0
+    age_pers_c  = (S,) vector, ages from 1 to S
+    age_pers_b  = (S+1,) vector, ages from 1 to S+1
+
+    FILES CREATED BY THIS FUNCTION:
+        SS_bc.png
+        SS_n.png
+
+    RETURNS: None
+    --------------------------------------------------------------------
+    '''
+    # Create directory if images directory does not already exist
+    cur_path = os.path.split(os.path.abspath(__file__))[0]
+    output_fldr = 'images'
+    output_dir = os.path.join(cur_path, output_fldr)
+    if not os.access(output_dir, os.F_OK):
+        os.makedirs(output_dir)
+
+    # Plot steady-state consumption and savings distributions
+    S = n_ss.shape[0]
+    b_ss_full = np.append(b_ss, 0)
+    age_pers_c = np.arange(1, S + 1)
+    age_pers_b = np.arange(1, S + 2)
+    fig, ax = plt.subplots()
+    plt.plot(age_pers_c, c_ss, marker='D', label='Consumption')
+    plt.plot(age_pers_b, b_ss_full, marker='D', label='Savings')
+    # for the minor ticks, use no labels; default NullFormatter
+    minorLocator = MultipleLocator(1)
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    # plt.title('Steady-state consumption and savings', fontsize=20)
+    plt.xlabel(r'Age $s$')
+    plt.ylabel(r'Units of consumption')
+    plt.xlim((0, S + 1))
+    # plt.ylim((-1.0, 1.15 * (b_ss.max())))
+    plt.legend(loc='upper left')
+    output_path = os.path.join(output_dir, 'SS_bc')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot steady-state labor supply distributions
+    fig, ax = plt.subplots()
+    plt.plot(age_pers_c, n_ss, marker='D', label='Labor supply')
+    # for the minor ticks, use no labels; default NullFormatter
+    minorLocator = MultipleLocator(1)
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    # plt.title('Steady-state labor supply', fontsize=20)
+    plt.xlabel(r'Age $s$')
+    plt.ylabel(r'Labor supply')
+    plt.xlim((0, S + 1))
+    # plt.ylim((-0.1, 1.15 * (n_ss.max())))
+    plt.legend(loc='upper right')
+    output_path = os.path.join(output_dir, 'SS_n')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()

--- a/DeBacker_Evans_simple/TPI.py
+++ b/DeBacker_Evans_simple/TPI.py
@@ -1,0 +1,680 @@
+'''
+------------------------------------------------------------------------
+This module contains the functions used to solve the transition path
+equilibrium using time path iteration (TPI) for the model with S-period
+lived agents and endogenous labor supply from Chapter 4 of the OG
+textbook.
+
+This Python module imports the following module(s):
+    aggregates.py
+    firms.py
+    households.py
+    utilities.py
+
+This Python module defines the following function(s):
+    get_path()
+    inner_loop()
+    get_TPI()
+    create_graphs()
+------------------------------------------------------------------------
+'''
+# Import Packages
+import time
+import numpy as np
+import aggregates as aggr
+import firms
+import households as hh
+import utilities as utils
+import scipy.optimize as opt
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+from mpl_toolkits.mplot3d import Axes3D
+from matplotlib import cm
+import os
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def get_path(x1, xT, T, spec):
+    '''
+    --------------------------------------------------------------------
+    This function generates a path from point x1 to point xT such that
+    that the path x is a linear or quadratic function of time t.
+
+        linear:    x = d*t + e
+        quadratic: x = a*t^2 + b*t + c
+
+    The identifying assumptions for quadratic are the following:
+
+        (1) x1 is the value at time t=0: x1 = c
+        (2) xT is the value at time t=T-1: xT = a*(T-1)^2 + b*(T-1) + c
+        (3) the slope of the path at t=T-1 is 0: 0 = 2*a*(T-1) + b
+    --------------------------------------------------------------------
+    INPUTS:
+    x1 = scalar, initial value of the function x(t) at t=0
+    xT = scalar, value of the function x(t) at t=T-1
+    T  = integer >= 3, number of periods of the path
+    spec = string, "linear" or "quadratic"
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    cc    = scalar, constant coefficient in quadratic function
+    bb    = scalar, coefficient on t in quadratic function
+    aa    = scalar, coefficient on t^2 in quadratic function
+    xpath = (T,) vector, parabolic xpath from x1 to xT
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: xpath
+    --------------------------------------------------------------------
+    '''
+    if spec == "linear":
+        xpath = np.linspace(x1, xT, T)
+    elif spec == "quadratic":
+        cc = x1
+        bb = 2 * (xT - x1) / (T - 1)
+        aa = (x1 - xT) / ((T - 1) ** 2)
+        xpath = (aa * (np.arange(0, T) ** 2) + (bb * np.arange(0, T)) +
+                 cc)
+
+    return xpath
+
+
+def inner_loop(rpath, wpath, args):
+    '''
+    --------------------------------------------------------------------
+    Given time paths for interest rates and wages, this function
+    generates matrices for the time path of the distribution of
+    individual consumption, labor supply, savings, the corresponding
+    Euler errors for the labor supply decision and the savings decision,
+    and the residual error of end-of-life savings associated with
+    solving each lifetime decision.
+    --------------------------------------------------------------------
+    INPUTS:
+    rpath = (T2+S-1,) vector, equilibrium time path of interest rate
+    wpath = (T2+S-1,) vector, equilibrium time path of the real wage
+    args  = length 12 tuple, (S, T2, beta, sigma, l_tilde, b_ellip,
+            upsilon, chi_n_vec, bvec1, n_ss, In_Tol, diff)
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        hh.get_n_errors()
+        hh.get_b_errors()
+    OBJECTS CREATED WITHIN FUNCTION:
+    S             = integer in [3,80], number of periods an individual
+                    lives
+    T2            = integer > S, number of periods until steady state
+    beta          = scalar in (0,1), discount factor
+    sigma         = scalar > 0, coefficient of relative risk aversion
+    l_tilde       = scalar > 0, time endowment for each agent each
+                    period
+    b_ellip       = scalar > 0, fitted value of b for elliptical
+                    disutility of labor
+    upsilon       = scalar > 1, fitted value of upsilon for elliptical
+                    disutility of labor
+    chi_n_vec     = (S,) vector, values for chi^n_s
+    bvec1         = (S,) vector, initial period savings distribution
+    In _tol       = scalar > 0, tolerance level for fsolve's in TPI
+    diff          = boolean, =True if want difference version of Euler
+                    errors beta*(1+r)*u'(c2) - u'(c1), =False if want
+                    ratio version [beta*(1+r)*u'(c2)]/[u'(c1)] - 1
+    cpath         = (S, T2+S-1) matrix, time path of the distribution of
+                    consumption
+    npath         = (S, T2+S-1) matrix, time path of the distribution of
+                    labor supply
+    bpath         = (S, T2+S-1) matrix, time path of the distribution of
+                    savings
+    n_err_path    = (S, T2+S-1) matrix, time path of distribution of
+                    labor supply Euler errors
+    b_err_path    = (S, T2+S-1) matrix, time path of distribution of
+                    savings Euler errors
+    bSp1_err_path = (S, T2) matrix, residual last period savings, which
+                    should be close to zero in equilibrium. Nonzero
+                    elements of matrix should only be in first column
+                    and first row
+    b_err_params  = length 2 tuple, args to pass into
+                    hh.get_b_errors()
+    p             = integer in [1, S-1], index representing number of
+                    periods remaining in a lifetime, used to solve
+                    incomplete lifetimes
+    cvec          = (p,) vector, individual lifetime consumption
+                    decisions
+    nvec          = (p,) vector, individual lifetime labor supply
+                    decisions
+    bvec          = (p,) vector, individual lifetime savings decisions
+    b_Sp1         = scalar, savings in last period for next period.
+                    Should be zero in equilibrium
+    DiagMaskc     = (p, p) boolean identity matrix
+    DiagMaskb     = (p-1, p-1) boolean identity matrix
+    n_err_params  = length 5 tuple, args to pass into hh.get_n_errors()
+    n_err_vec     = (p,) vector, individual lifetime labor supply Euler
+                    errors
+    b_err_vec     = (p-1,) vector, individual lifetime savings Euler
+                    errors
+    t             = integer in [0,T2-1], index of time period (minus 1)
+    FILES CREATED BY THIS FUNCTION: None
+    RETURNS: cpath, npath, bpath, n_err_path, b_err_path, bSp1_err_path
+    --------------------------------------------------------------------
+    '''
+    (S, T2, beta, sigma, l_tilde, b_ellip, upsilon, chi_n_vec, bvec1,
+     n_ss, In_Tol, diff) = args
+    cpath = np.zeros((S, T2 + S - 1))
+    npath = np.zeros((S, T2 + S - 1))
+    bpath = np.append(bvec1.reshape((S, 1)),
+                      np.zeros((S, T2 + S - 2)), axis=1)
+    n_err_path = np.zeros((S, T2 + S - 1))
+    b_err_path = np.zeros((S, T2 + S - 1))
+    b_err_args = (beta, sigma, diff)
+
+    # Solve the incomplete remaining lifetime decisions of agents alive
+    # in period t=1 but not born in period t=1
+    for p in range(1, S):
+
+        if p == 1:
+            # p=1 individual only has an s=S labor supply decision n_S
+            n_S1_init = n_ss[-1]
+            nS1_args = (wpath[0], sigma, l_tilde, chi_n_vec[-1],
+                        b_ellip, upsilon, diff, rpath[0], bvec1[-1],
+                        0.0)
+            results_nS1 = opt.root(hh.get_n_errors, n_S1_init,
+                                   args=(nS1_args), method='lm',
+                                   tol=In_Tol)
+            n_S1 = results_nS1.x
+            npath[-1, 0] = n_S1
+            n_err_path[-1, 0] = results_nS1.fun
+            cpath[-1, 0] = hh.get_cons(rpath[0], wpath[0], bvec1[-1],
+                                       0.0, n_S1)
+
+        else:
+            # 1<p<S chooses b_{s+1} and n_s and has incomplete lives
+            DiagMaskb = np.eye(p - 1, dtype=bool)
+            DiagMaskn = np.eye(p, dtype=bool)
+            b_sp1_init = np.diag(bpath[S - p + 1:, :p - 1])
+            n_s_init = np.hstack((n_ss[S - p],
+                                  np.diag(npath[S - p + 1:, :p - 1])))
+            bn_init = np.hstack((b_sp1_init, n_s_init))
+            bn_args = (rpath[:p], wpath[:p], bvec1[-p], p, beta, sigma,
+                       l_tilde, chi_n_vec[-p:], b_ellip, upsilon, diff)
+            results_bn = opt.root(hh.bn_errors, bn_init, args=(bn_args),
+                                  tol=In_Tol)
+            bvec = results_bn.x[:p - 1]
+            nvec = results_bn.x[p - 1:]
+            b_s_vec = np.append(bvec1[-p], bvec)
+            b_sp1_vec = np.append(bvec, 0.0)
+            cvec = hh.get_cons(rpath[:p], wpath[:p], b_s_vec, b_sp1_vec,
+                               nvec)
+            npath[S - p:, :p] = DiagMaskn * nvec + npath[S - p:, :p]
+            bpath[S - p + 1:, 1:p] = (DiagMaskb * bvec +
+                                      bpath[S - p + 1:, 1:p])
+            cpath[S - p:, :p] = DiagMaskn * cvec + cpath[S - p:, :p]
+            n_args = (wpath[:p], sigma, l_tilde, chi_n_vec[-p:],
+                      b_ellip, upsilon, diff, cvec)
+            n_errors = hh.get_n_errors(nvec, *n_args)
+            n_err_path[S - p:, :p] = (DiagMaskn * n_errors +
+                                      n_err_path[S - p:, :p])
+            b_errors = hh.get_b_errors(cvec, rpath[1:p], *b_err_args)
+            b_err_path[S - p + 1:, 1:p] = (DiagMaskb * b_errors +
+                                           b_err_path[S - p + 1:, 1:p])
+
+    # Solve the complete remaining lifetime decisions of agents born
+    # between period t=1 and t=T2
+    for t in range(T2):
+        DiagMaskb = np.eye(S - 1, dtype=bool)
+        DiagMaskn = np.eye(S, dtype=bool)
+        b_sp1_init = np.diag(bpath[1:, t:t + S - 1])
+        if t == 0:
+            n_s_init = np.hstack((n_ss[0],
+                                  np.diag(npath[1:, t:t + S - 1])))
+        else:
+            n_s_init = np.diag(npath[:, t - 1:t + S - 1])
+        bn_init = np.hstack((b_sp1_init, n_s_init))
+        bn_args = (rpath[t:t + S], wpath[t:t + S], 0.0, S, beta, sigma,
+                   l_tilde, chi_n_vec, b_ellip, upsilon, diff)
+        results_bn = opt.root(hh.bn_errors, bn_init, args=(bn_args),
+                              tol=In_Tol)
+        bvec = results_bn.x[:S - 1]
+        nvec = results_bn.x[S - 1:]
+        b_s_vec = np.append(0.0, bvec)
+        b_sp1_vec = np.append(bvec, 0.0)
+        cvec = hh.get_cons(rpath[t:t + S], wpath[t:t + S], b_s_vec,
+                           b_sp1_vec, nvec)
+        npath[:, t:t + S] = DiagMaskn * nvec + npath[:, t:t + S]
+        bpath[1:, t + 1:t + S] = (DiagMaskb * bvec +
+                                  bpath[1:, t + 1:t + S])
+        cpath[:, t:t + S] = DiagMaskn * cvec + cpath[:, t:t + S]
+        n_args = (wpath[t:t + S], sigma, l_tilde, chi_n_vec, b_ellip,
+                  upsilon, diff, cvec)
+        n_errors = hh.get_n_errors(nvec, *n_args)
+        n_err_path[:, t:t + S] = (DiagMaskn * n_errors +
+                                  n_err_path[:, t:t + S])
+        b_errors = hh.get_b_errors(cvec, rpath[t + 1:t + S], *b_err_args)
+        b_err_path[1:, t + 1:t + S] = (DiagMaskb * b_errors +
+                                       b_err_path[1:, t + 1:t + S])
+
+    return cpath, npath, bpath, n_err_path, b_err_path
+
+
+def get_TPI(bvec1, args, graphs):
+    '''
+    --------------------------------------------------------------------
+    Solves for transition path equilibrium using time path iteration
+    (TPI)
+    --------------------------------------------------------------------
+    INPUTS:
+    bvec1  = (S,) vector, initial period savings distribution
+    args   = length 22 tuple, (S, T1, T2, beta, sigma, l_tilde, b_ellip,
+             upsilon, chi_n_vec, A, alpha, delta, r_ss, K_ss, L_ss,
+             C_ss, b_ss, n_ss, maxiter, Out_Tol, In_Tol, EulDiff, xi)
+    graphs = Boolean, =True if want graphs of TPI objects
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        aggr.get_K()
+        get_path()
+        firms.get_r()
+        firms.get_w()
+        inner_loop()
+        solve_bn_path()
+        aggr.get_L()
+        aggr.get_Y()
+        aggr.get_C()
+        utils.print_time()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    start_time    = scalar, current processor time in seconds (float)
+    S             = integer in [3,80], number of periods an individual
+                    lives
+    T1            = integer > S, number of time periods until steady
+                    state is assumed to be reached
+    T2            = integer > T1, number of time periods after which
+                    steady-state is forced in TPI
+    beta          = scalar in (0,1), discount factor for model period
+    sigma         = scalar > 0, coefficient of relative risk aversion
+    l_tilde       = scalar > 0, time endowment for each agent each
+                    period
+    b_ellip       = scalar > 0, fitted value of b for elliptical
+                    disutility of labor
+    upsilon       = scalar > 1, fitted value of upsilon for elliptical
+                    disutility of labor
+    chi_n_vec     = (S,) vector, values for chi^n_s
+    A             = scalar > 0, total factor productivity parameter in
+                    firms' production function
+    alpha         = scalar in (0,1), capital share of income
+    delta         = scalar in [0,1], per-period capital depreciation rt
+    r_ss          = scalar > 0, steady-state aggregate interest rate
+    K_ss          = scalar > 0, steady-state aggregate capital stock
+    L_ss          = scalar > 0, steady-state aggregate labor
+    C_ss          = scalar > 0, steady-state aggregate consumption
+    b_ss          = (S,) vector, steady-state savings distribution
+                    (b1, b2,... bS)
+    n_ss          = (S,) vector, steady-state labor supply distribution
+                    (n1, n2,... nS)
+    maxiter       = integer >= 1, Maximum number of iterations for TPI
+    mindist       = scalar > 0, convergence criterion for TPI
+    TPI_tol       = scalar > 0, tolerance level for TPI root finders
+    xi            = scalar in (0,1], TPI path updating parameter
+    diff          = Boolean, =True if want difference version of Euler
+                    errors beta*(1+r)*u'(c2) - u'(c1), =False if want
+                    ratio version [beta*(1+r)*u'(c2)]/[u'(c1)] - 1
+    K1            = scalar > 0, initial aggregate capital stock
+    K1_cnstr      = Boolean, =True if K1 <= 0
+    rpath_init    = (T2+S-1,) vector, initial guess for the time path of
+                    interest rates
+    iter_TPI      = integer >= 0, current iteration of TPI
+    dist          = scalar >= 0, distance measure between initial and
+                    new paths
+    rw_params     = length 3 tuple, (A, alpha, delta)
+    Y_params      = length 2 tuple, (A, alpha)
+    cnb_params    = length 11 tuple, args to pass into inner_loop()
+    rpath         = (T2+S-1,) vector, time path of the interest rates
+    wpath         = (T2+S-1,) vector, time path of the wages
+    ind           = (S,) vector, integers from 0 to S
+    bn_args       = length 14 tuple, arguments to be passed to
+                    solve_bn_path()
+    cpath         = (S, T2+S-1) matrix, time path of distribution of
+                    individual consumption c_{s,t}
+    npath         = (S, T2+S-1) matrix, time path of distribution of
+                    individual labor supply n_{s,t}
+    bpath         = (S, T2+S-1) matrix, time path of distribution of
+                    individual savings b_{s,t}
+    n_err_path    = (S, T2+S-1) matrix, time path of distribution of
+                    individual labor supply Euler errors
+    b_err_path    = (S, T2+S-1) matrix, time path of distribution of
+                    individual savings Euler errors. First column and
+                    first row are identically zero
+    bSp1_err_path = (S, T2) matrix, residual last period savings, which
+                    should be close to zero in equilibrium. Nonzero
+                    elements of matrix should only be in first column
+                    and first row
+    Kpath_new     = (T2+S-1,) vector, new path of the aggregate capital
+                    stock implied by household and firm optimization
+    Kpath_cnstr   = (T2+S-1,) Boolean vector, =True if K_t<=0
+    Lpath_new     = (T2+S-1,) vector, new path of the aggregate labor
+    rpath_new     = (T2+S-1,) vector, updated time path of interest rate
+    wpath_new     = (T2+S-1,) vector, updated time path of the wages
+    Ypath         = (T2+S-1,) vector, equilibrium time path of aggregate
+                    output (GDP) Y_t
+    Cpath         = (T2+S-1,) vector, equilibrium time path of aggregate
+                    consumption C_t
+    RCerrPath     = (T2+S-2,) vector, equilibrium time path of the
+                    resource constraint error:
+                    Y_t - C_t - K_{t+1} + (1-delta)*K_t
+    Kpath         = (T2+S-1,) vector, equilibrium time path of aggregate
+                    capital stock K_t
+    Lpath         = (T2+S-1,) vector, equilibrium time path of aggregate
+                    labor L_t
+    tpi_time      = scalar, time to compute TPI solution (seconds)
+    tpi_output    = length 14 dictionary, {cpath, npath, bpath, wpath,
+                    rpath, Kpath, Lpath, Ypath, Cpath, bSp1_err_path,
+                    n_err_path, b_err_path, RCerrPath, tpi_time}
+
+    FILES CREATED BY THIS FUNCTION:
+        Kpath.png
+        Lpath.png
+        Ypath.png
+        C_aggr_path.png
+        wpath.png
+        rpath.png
+        cpath.png
+        npath.png
+        bpath.png
+
+    RETURNS: tpi_output
+    --------------------------------------------------------------------
+    '''
+    start_time = time.clock()
+    (S, T1, T2, beta, sigma, l_tilde, b_ellip, upsilon, chi_n_vec, A,
+        alpha, delta, r_ss, K_ss, L_ss, C_ss, b_ss, n_ss, maxiter,
+        Out_Tol, In_Tol, EulDiff, xi) = args
+    K1, K1_cnstr = aggr.get_K(bvec1)
+
+    # Create time path for r
+    rpath_init = np.zeros(T2 + S - 1)
+    rpath_init[:T1] = get_path(r_ss, r_ss, T1, 'quadratic')
+    rpath_init[T1:] = r_ss
+
+    iter_TPI = int(0)
+    dist = 10.0
+    rw_params = (A, alpha, delta)
+    Y_params = (A, alpha)
+    cnb_args = (S, T2, beta, sigma, l_tilde, b_ellip, upsilon,
+                chi_n_vec, bvec1, n_ss, In_Tol, EulDiff)
+    while (iter_TPI < maxiter) and (dist >= Out_Tol):
+        iter_TPI += 1
+        rpath = rpath_init
+        wpath = firms.get_w(rpath_init, rw_params)
+        cpath, npath, bpath, n_err_path, b_err_path = \
+            inner_loop(rpath, wpath, cnb_args)
+        Kpath_new = np.zeros(T2 + S - 1)
+        Kpath_new[:T2], Kpath_cstr = aggr.get_K(bpath[:, :T2])
+        Kpath_new[T2:] = K_ss
+        Kpath_cstr = np.append(Kpath_cstr, np.zeros(S - 1, dtype=bool))
+        Lpath_new = np.zeros(T2 + S - 1)
+        Lpath_new[:T2], Lpath_cstr = aggr.get_L(npath[:, :T2])
+        Lpath_new[T2:] = L_ss
+        Lpath_cstr = np.append(Lpath_cstr, np.zeros(S - 1, dtype=bool))
+        rpath_new = firms.get_r(Kpath_new, Lpath_new, rw_params)
+        wpath = firms.get_w(rpath_new, rw_params)
+        Ypath = aggr.get_Y(Kpath_new, Lpath_new, Y_params)
+        Cpath = np.zeros(T2 + S - 1)
+        Cpath[:T2] = aggr.get_C(cpath[:, :T2])
+        Cpath[T2:] = C_ss
+        RCerrPath = (Ypath[:-1] - Cpath[:-1] - Kpath_new[1:] +
+                     (1 - delta) * Kpath_new[:-1])
+        # Check the distance of rpath_new
+        dist = (np.absolute(rpath_new[:T2] - rpath_init[:T2])).sum()
+        print(
+            'TPI iter: ', iter_TPI, ', dist: ', "%10.4e" % (dist),
+            ', max abs all errs: ', "%10.4e" %
+            (np.absolute(np.hstack((b_err_path.max(axis=0),
+             n_err_path.max(axis=0)))).max()))
+        # The resource constraint does not bind across the transition
+        # path until the equilibrium is solved
+        rpath_init[:T2] = (xi * rpath_new[:T2] +
+                           (1 - xi) * rpath_init[:T2])
+    if (iter_TPI == maxiter) and (dist > Out_Tol):
+        print('TPI reached maxiter and did not converge.')
+    elif (iter_TPI == maxiter) and (dist <= Out_Tol):
+        print('TPI converged in the last iteration. ' +
+              'Should probably increase maxiter_TPI.')
+    Kpath = Kpath_new
+    Lpath = Lpath_new
+
+    tpi_time = time.clock() - start_time
+
+    tpi_output = {
+        'cpath': cpath, 'npath': npath, 'bpath': bpath, 'wpath': wpath,
+        'rpath': rpath, 'Kpath': Kpath, 'Lpath': Lpath, 'Ypath': Ypath,
+        'Cpath': Cpath, 'n_err_path': n_err_path,
+        'b_err_path': b_err_path, 'RCerrPath': RCerrPath,
+        'tpi_time': tpi_time}
+
+    # Print maximum resource constraint error. Only look at resource
+    # constraint up to period T2 - 1 because period T2 includes K_{t+1},
+    # which was forced to be the steady-state
+    print('Max abs. RC error: ', "%10.4e" %
+          (np.absolute(RCerrPath[:T2 - 1]).max()))
+
+    # Print TPI computation time
+    utils.print_time(tpi_time, 'TPI')
+
+    if graphs:
+        graph_args = (S, T2)
+        create_graphs(tpi_output, graph_args)
+
+    return tpi_output
+
+
+def create_graphs(tpi_output, args):
+    '''
+    --------------------------------------------------------------------
+    Plot equilibrium time path results
+    --------------------------------------------------------------------
+    INPUTS:
+    tpi_output = length 13 dict, equilibrium time paths and computation
+                 time from TPI computation
+    args       = length 2 tuple, (S, T2)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    S           =
+    T2          =
+    Kpath       =
+    Lpath       =
+    rpath       =
+    wpath       =
+    Ypath       =
+    Cpath       =
+    cpath       =
+    npath       =
+    bpath       =
+    cur_path    = string, path name of current directory
+    output_fldr = string, folder in current path to save files
+    output_dir  = string, total path of images folder
+    output_path = string, path of file name of figure to be saved
+    tvec        = (T2+S-1,) vector, time period vector
+    tgridT      = (T2,) vector, time period vector from 1 to T2
+    sgrid       = (S,) vector, all ages from 1 to S
+    tmat        = (S, T2) matrix, time periods for decisions ages
+                  (S) and time periods (T2)
+    smat        = (S, T2) matrix, ages for all decisions ages (S)
+                  and time periods (T2)
+    cmap_c      =
+    cmap_n      =
+    bpath_full  =
+    sgrid_b     =
+    tmat_b      =
+    smat_b      =
+    cmap_b      =
+
+    FILES CREATED BY THIS FUNCTION:
+        Kpath.png
+        Lpath.png
+        rpath.png
+        wpath.png
+        Ypath.png
+        C_aggr_path.png
+        cpath.png
+        npath.png
+        bpath.png
+
+    RETURNS: None
+    --------------------------------------------------------------------
+    '''
+    S, T2 = args
+    Kpath = tpi_output['Kpath']
+    Lpath = tpi_output['Lpath']
+    rpath = tpi_output['rpath']
+    wpath = tpi_output['wpath']
+    Ypath = tpi_output['Ypath']
+    Cpath = tpi_output['Cpath']
+    cpath = tpi_output['cpath']
+    npath = tpi_output['npath']
+    bpath = tpi_output['bpath']
+
+    # Create directory if images directory does not already exist
+    cur_path = os.path.split(os.path.abspath(__file__))[0]
+    output_fldr = 'images'
+    output_dir = os.path.join(cur_path, output_fldr)
+    if not os.access(output_dir, os.F_OK):
+        os.makedirs(output_dir)
+
+    # Plot time path of aggregate capital stock
+    tvec = np.linspace(1, T2 + S - 1, T2 + S - 1)
+    minorLocator = MultipleLocator(1)
+    fig, ax = plt.subplots()
+    plt.plot(tvec, Kpath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for aggregate capital stock K')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Aggregate capital $K_{t}$')
+    output_path = os.path.join(output_dir, 'Kpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of aggregate capital stock
+    fig, ax = plt.subplots()
+    plt.plot(tvec, Lpath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for aggregate labor L')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Aggregate labor $L_{t}$')
+    output_path = os.path.join(output_dir, 'Lpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of aggregate output (GDP)
+    fig, ax = plt.subplots()
+    plt.plot(tvec, Ypath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for aggregate output (GDP) Y')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Aggregate output $Y_{t}$')
+    output_path = os.path.join(output_dir, 'Ypath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of aggregate consumption
+    fig, ax = plt.subplots()
+    plt.plot(tvec, Cpath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for aggregate consumption C')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Aggregate consumption $C_{t}$')
+    output_path = os.path.join(output_dir, 'C_aggr_path')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of real wage
+    fig, ax = plt.subplots()
+    plt.plot(tvec, wpath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for real wage w')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Real wage $w_{t}$')
+    output_path = os.path.join(output_dir, 'wpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of real interest rate
+    fig, ax = plt.subplots()
+    plt.plot(tvec, rpath, marker='D')
+    # for the minor ticks, use no labels; default NullFormatter
+    ax.xaxis.set_minor_locator(minorLocator)
+    plt.grid(b=True, which='major', color='0.65', linestyle='-')
+    plt.title('Time path for real interest rate r')
+    plt.xlabel(r'Period $t$')
+    plt.ylabel(r'Real interest rate $r_{t}$')
+    output_path = os.path.join(output_dir, 'rpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of individual consumption distribution
+    tgridT = np.linspace(1, T2, T2)
+    sgrid = np.linspace(1, S, S)
+    tmat, smat = np.meshgrid(tgridT, sgrid)
+    cmap_c = cm.get_cmap('summer')
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+    ax.set_xlabel(r'period-$t$')
+    ax.set_ylabel(r'age-$s$')
+    ax.set_zlabel(r'individual consumption $c_{s,t}$')
+    strideval = max(int(1), int(round(S / 10)))
+    ax.plot_surface(tmat, smat, cpath[:, :T2], rstride=strideval,
+                    cstride=strideval, cmap=cmap_c)
+    output_path = os.path.join(output_dir, 'cpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of individual labor supply distribution
+    cmap_n = cm.get_cmap('summer')
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+    ax.set_xlabel(r'period-$t$')
+    ax.set_ylabel(r'age-$s$')
+    ax.set_zlabel(r'individual labor supply $n_{s,t}$')
+    strideval = max(int(1), int(round(S / 10)))
+    ax.plot_surface(tmat, smat, npath[:, :T2], rstride=strideval,
+                    cstride=strideval, cmap=cmap_n)
+    output_path = os.path.join(output_dir, 'npath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()
+
+    # Plot time path of individual savings distribution
+    bpath_full = np.vstack((bpath, np.zeros((1, bpath.shape[1]))))
+    sgrid_b = np.linspace(1, S + 1, S + 1)
+    tmat_b, smat_b = np.meshgrid(tgridT, sgrid_b)
+    cmap_b = cm.get_cmap('summer')
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+    ax.set_xlabel(r'period-$t$')
+    ax.set_ylabel(r'age-$s$')
+    ax.set_zlabel(r'individual savings $b_{s,t}$')
+    strideval = max(int(1), int(round(S / 10)))
+    ax.plot_surface(tmat_b, smat_b, bpath_full[:, :T2],
+                    rstride=strideval, cstride=strideval, cmap=cmap_b)
+    output_path = os.path.join(output_dir, 'bpath')
+    plt.savefig(output_path)
+    # plt.show()
+    plt.close()

--- a/DeBacker_Evans_simple/aggregates.py
+++ b/DeBacker_Evans_simple/aggregates.py
@@ -1,0 +1,211 @@
+'''
+------------------------------------------------------------------------
+This module contains the functions that generate aggregate variables in
+the steady-state or in the transition path of the overlapping
+generations model with S-period lived agents and endogenous labor supply
+from Chapter 7 of the OG textbook.
+
+This Python module imports the following module(s): None
+
+This Python module defines the following function(s):
+    get_L()
+    get_K()
+    get_Y()
+    get_C()
+------------------------------------------------------------------------
+'''
+# Import packages
+import numpy as np
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def get_L(narr):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state aggregate labor L or time path of aggregate
+    labor L_t
+
+    We have included a stitching function for L when L<=epsilon such
+    that the the adjusted value is the following. Let sum(n_i) = X.
+    Market clearing is usually given by L = X:
+
+    L = X when X >= epsilon
+      = f(X) = a * exp(b * X) when X < epsilon
+                   where a = epsilon / e  and b = 1 / epsilon
+
+    This function has the properties that
+    (i) f(X)>0 and f'(X) > 0 for all X,
+    (ii) f(eps) = eps (i.e., functions X and f(X) meet at epsilon)
+    (iii) f'(eps) = 1 (i.e., slopes of X and f(X) are equal at epsilon)
+    --------------------------------------------------------------------
+    INPUTS:
+    narr = (S,) vector or (S, T_S-1) matrix, values for steady-state
+           labor supply (n1, n2, ...nS) or time path of the distribution
+           of labor supply
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    epsilon = scalar > 0, small value at which stitch f(K) function
+    a       = scalar > 0, scale parameter on stitching function
+    b       = scalar > 0, coefficient on X in exponent of stitching
+              function
+    L       = scalar > 0, aggregate labor
+    L_cstr  = boolean or (T+S-2,) boolean vector, =True if L <= epsilon
+              or if L_t <= epsilon
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: L, L_cstr
+    --------------------------------------------------------------------
+    '''
+    epsilon = 0.1
+    a = epsilon / np.exp(1)
+    b = 1 / epsilon
+    if narr.ndim == 1:  # This is the steady-state case
+        L = narr.sum()
+        L_cstr = L < epsilon
+        if L_cstr:
+            print('get_L() warning: distribution of labor supply ' +
+                  'and/or parameters created L < epsilon')
+            # Force L > 0 by stitching a * exp(b * L) for L < eps
+            L = a * np.exp(b * L)
+    elif narr.ndim == 2:  # This is the time path case
+        L = narr.sum(axis=0)
+        L_cstr = L < epsilon
+        if L.min() < epsilon:
+            print('Aggregate labor constraint is violated ' +
+                  '(L_t < epsilon) for some period in time path.')
+            L[L_cstr] = a * np.exp(b * L[L_cstr])
+
+    return L, L_cstr
+
+
+def get_K(barr):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state aggregate capital stock K or time path of
+    aggregate capital stock K_t.
+
+    We have included a stitching function for K when K<=epsilon such
+    that the the adjusted value is the following. Let sum(b_i) = X.
+    Market clearing is usually given by K = X:
+
+    K = X when X >= epsilon
+      = f(X) = a * exp(b * X) when X < epsilon
+                   where a = epsilon / e  and b = 1 / epsilon
+
+    This function has the properties that
+    (i) f(X)>0 and f'(X) > 0 for all X,
+    (ii) f(eps) = eps (i.e., functions X and f(X) meet at epsilon)
+    (iii) f'(eps) = 1 (i.e., slopes of X and f(X) are equal at epsilon)
+    --------------------------------------------------------------------
+    INPUTS:
+    barr = (S,) vector or (S, T+S-1) matrix, values for steady-state
+           savings (b_1, b_2,b_3,...b_S) or time path of the
+           distribution of savings
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    epsilon = scalar > 0, small value at which stitch f(K) function
+    a       = scalar > 0, scale parameter on stitching function
+    b       = scalar > 0, coefficient on X in exponent of stitching
+              function
+    K       = scalar or (T+S-2,) vector, steady-state aggregate capital
+              stock or time path of aggregate capital stock
+    K_cstr  = boolean or (T+S-2) boolean vector, =True if K <= epsilon
+              or if K_t <= epsilon
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: K, K_cstr
+    --------------------------------------------------------------------
+    '''
+    epsilon = 0.1
+    a = epsilon / np.exp(1)
+    b = 1 / epsilon
+    if barr.ndim == 1:  # This is the steady-state case
+        K = barr.sum()
+        K_cstr = K < epsilon
+        if K_cstr:
+            print('get_K() warning: distribution of savings and/or ' +
+                  'parameters created K < epsilon')
+            # Force K > 0 by stitching a * exp(b * K) for K < eps
+            K = a * np.exp(b * K)
+
+    elif barr.ndim == 2:  # This is the time path case
+        K = barr.sum(axis=0)
+        K_cstr = K < epsilon
+        if K.min() < epsilon:
+            print('Aggregate capital constraint is violated ' +
+                  '(K_t < epsilon) for some period in time path.')
+            K[K_cstr] = a * np.exp(b * K[K_cstr])
+
+    return K, K_cstr
+
+
+def get_Y(K, L, params):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state aggregate output Y or time path of aggregate
+    output Y_t
+    --------------------------------------------------------------------
+    INPUTS:
+    K      = scalar > 0 or (T+S-2,) vector, aggregate capital stock
+             or time path of the aggregate capital stock
+    L      = scalar > 0 or (T+S-2,) vector, aggregate labor or time
+             path of the aggregate labor
+    params = length 2 tuple, production function parameters
+             (A, alpha)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    A      = scalar > 0, total factor productivity
+    alpha  = scalar in (0,1), capital share of income
+    Y      = scalar > 0 or (T+S-2,) vector, aggregate output (GDP) or
+             time path of aggregate output (GDP)
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: Y
+    --------------------------------------------------------------------
+    '''
+    A, alpha = params
+    Y = A * (K ** alpha) * (L ** (1 - alpha))
+
+    return Y
+
+
+def get_C(carr):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state aggregate consumption C or time path of
+    aggregate consumption C_t
+    --------------------------------------------------------------------
+    INPUTS:
+    carr = (S,) vector or (S, T) matrix, distribution of consumption c_s
+           in steady state or time path for the distribution of
+           consumption
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    C = scalar > 0 or (T,) vector, aggregate consumption or time path of
+        aggregate consumption
+
+    Returns: C
+    --------------------------------------------------------------------
+    '''
+    if carr.ndim == 1:
+        C = carr.sum()
+    elif carr.ndim == 2:
+        C = carr.sum(axis=0)
+
+    return C

--- a/DeBacker_Evans_simple/elliputil.py
+++ b/DeBacker_Evans_simple/elliputil.py
@@ -1,0 +1,321 @@
+'''
+------------------------------------------------------------------------
+This module defines functions for fitting the elliptical disutility of
+labor functional form to the constant Frisch elasticity (CFE) disutility
+of labor functional form.
+
+This module defines the following functions:
+    gen_ellip()
+    gen_uprightquad()
+    MU_sumsq()
+    fit_ellip_CFE()
+------------------------------------------------------------------------
+'''
+
+# Import packages
+import numpy as np
+import scipy.optimize as opt
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+from matplotlib.patches import Ellipse
+import os
+
+'''
+------------------------------------------------------------------------
+Define functions
+------------------------------------------------------------------------
+'''
+
+
+def gen_ellip(h, k, a, b, mu, graph=True):
+    '''
+    --------------------------------------------------------------------
+    This plots the general functional form of an ellipse and highlights
+    the upper-right quadrant.
+
+    [([x - h] / a) ** mu] + [([y - k] / b) ** mu] = 1
+    --------------------------------------------------------------------
+    INPUTS:
+    h     = scalar, x-coordinate of centroid (h, k)
+    k     = scalar, y-coordinate of centroid (h, k)
+    a     = scalar > 0, horizontal radius of ellipse
+    b     = scalar > 0, vertical radius of ellipse
+    mu    = scalar > 0, curvature parameter of ellipse
+    graph = boolean, =True if graph output
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    N    = integer > 0, number of elements in the support of x
+    xvec = (N,) vector, support of x variable
+    yvec = (N,) vector, values of y corresponding to the upper-right
+           quadrant values of the ellipse from xvec
+
+    FILES CREATED BY THIS FUNCTION:
+        images/EllipseGen.png
+
+    RETURNS: xvec, yvec
+    --------------------------------------------------------------------
+    '''
+    N = 1000
+    xvec = np.linspace(h, h + a, N)
+    yvec = b * ((1 - (((xvec - h) / a) ** mu)) ** (1 / mu)) + k
+    if graph:
+        e1 = Ellipse((h, k), 2 * a, 2 * b, 360.0, linewidth=2.0,
+                     fill=False, label='Full ellipse')
+        fig = plt.figure()
+        ax = fig.add_subplot(111, aspect='equal')
+        ax.add_patch(e1)
+        plt.plot(xvec, yvec, color='r', linewidth=4,
+                 label='Upper-right quadrant')
+        # for the minor ticks, use no labels; default NullFormatter
+        minorLocator = MultipleLocator(1)
+        ax.xaxis.set_minor_locator(minorLocator)
+        plt.grid(b=True, which='major', color='0.65', linestyle='-')
+        plt.xlabel(r'$x$')
+        plt.ylabel(r'$y$')
+        plt.xlim((h - 1.6 * a, h + 1.6 * a))
+        plt.ylim((k - 1.4 * b, k + 1.4 * b))
+        # plt.legend(loc='upper right')
+        figname = "images/EllipseGen"
+        plt.savefig(figname)
+        print("Saved figure: " + figname)
+        # plt.show()
+        plt.close()
+
+    return xvec, yvec
+
+
+def gen_uprightquad(hvec, kvec, avec, bvec, muvec, graph=True):
+    '''
+    --------------------------------------------------------------------
+    This plots only the upper-right quadrant of potentially multiple
+    ellipses of the form:
+
+    [([x - h] / a) ** mu] + [([y - k] / b) ** mu] = 1
+    --------------------------------------------------------------------
+    INPUTS:
+    hvec  = (I,) vector, x-coordinate of centroid (h, k) of each of I
+            ellipses
+    kvec  = (I,) vector, y-coordinate of centroid (h, k) of each of I
+            ellipses
+    avec  = (I,) vector > 0, horizontal radius of ellipse for each of I
+            ellipses
+    bvec  = (I,) vector > 0, vertical radius of ellipse for each of I
+            ellipses
+    muvec = (I,) vector > 0, curvature parameter of ellipse for each of
+            I ellipses
+    graph = boolean, =True if graph output
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    II   = integer >= 1, number of ellipses to produce
+    N    = integer >= 1, number of elements (many) in the support of x
+    xmat = (I, N) matrix, support of x variable for I ellipses
+    ymat = (I, N) matrix, values of y corresponding to the upper-right
+           quadrant values of I ellipses from xmat
+
+    FILES CREATED BY THIS FUNCTION:
+        images/UpRightQuadEllipses.png
+
+    RETURNS: xmat, ymat
+    --------------------------------------------------------------------
+    '''
+    II = len(hvec)
+    N = 1000
+    xmat = np.zeros((II, N))
+    ymat = np.zeros((II, N))
+    for i in range(II):
+        xmat[i, :] = np.linspace(hvec[i], hvec[i] + avec[i], N)
+        ymat[i, :] = \
+            (bvec[i] *
+             ((1 - (((xmat[i, :] - hvec[i]) / avec[i]) ** muvec[i])) **
+             (1 / muvec[i])) + kvec[i])
+    if graph:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, aspect='equal')
+        for i in range(II):
+            plt.plot(xmat[i, :], ymat[i, :], linewidth=4,
+                     label='Ellipse ' + str(i + 1))
+        # for the minor ticks, use no labels; default NullFormatter
+        minorLocator = MultipleLocator(1)
+        ax.xaxis.set_minor_locator(minorLocator)
+        plt.grid(b=True, which='major', color='0.65', linestyle='-')
+        plt.xlabel(r'$x$')
+        plt.ylabel(r'$y$')
+        # plt.xlim((hvec - 1.6 * avec, hvec + 1.6 * avec))
+        # plt.ylim((kvec - 1.4 * bvec, kvec + 1.4 * bvec))
+        plt.legend(loc='upper right')
+        figname = "images/UpRightQuadEllipses"
+        plt.savefig(figname)
+        print("Saved figure: " + figname)
+        # plt.show()
+        plt.close()
+
+    return xmat, ymat
+
+
+def MU_sumsq(ellip_params, *args):
+    '''
+    --------------------------------------------------------------------
+    This function calculates the sum of squared errors between two
+    marginal utility of leisure functions across the support of leisure
+    --------------------------------------------------------------------
+    INPUTS:
+    ellip_params = (2,) vector, scale parameter b and shape parameter
+                   upsilon of elliptical disutility of labor
+    args         = length 4 tuple,
+                   (Frisch, CFE_scale, l_tilde, labor_sup)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    b_ellip    = scalar > 0, scale parameter of elliptical disutility of
+                 labor
+    upsilon    = scalar > 1, shape parameter of elliptical disutility of
+                 labor
+    Frisch     = scalar > 0, Frisch elasticity of labor supply in CFE
+                 disutility of labor function
+    CFE_scale  = scalar > 0, level parameter for CFE disutility of labor
+                 function
+    l_tilde    = scalar > 0, time endowment for each agent each period
+    labor_sup  = (N,) vector, points in support of labor supply
+    MU_CFE     = (N,) vector, CFE marginal disutility of labor for
+                 labor_sup
+    MU_ellip   = (N,) vector, elliptical marginal disutility of labor
+                 for labor_sup
+    sumsq      = scalar > 0, sum of squared errors between elliptical
+                 and CFE marginal utility functions
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: sumsq
+    --------------------------------------------------------------------
+    '''
+    b_ellip, upsilon = ellip_params
+    Frisch, CFE_scale, l_tilde, labor_sup = args
+
+    MU_CFE = CFE_scale * (labor_sup ** (1 / Frisch))
+    MU_ellip = ((b_ellip / l_tilde) *
+                ((labor_sup / l_tilde) ** (upsilon - 1)) *
+                ((1 - ((labor_sup / l_tilde) ** upsilon)) **
+                ((1 - upsilon) / upsilon)))
+    sumsq = ((MU_ellip - MU_CFE) ** 2).sum()
+
+    return sumsq
+
+
+def fit_ellip_CFE(ellip_init, cfe_params, l_tilde, graph):
+    '''
+    --------------------------------------------------------------------
+    This function estimates the elliptical disutility of labor
+    parameters
+    --------------------------------------------------------------------
+    INPUTS:
+    ellip_init = (2,) vector, initial guesses for b and upsilon
+    cfe_params = (2,) vector, parameters for CFE disutility of labor
+                 parameters: Frisch elasticity and scale parameter
+    l_tilde    = scalar > 0, time endowment to each agent each period
+    graph      = Boolean, =True want to save plots of results
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    Frisch       = scalar > 0, Frisch elasticity of labor supply
+    CFE_scale    = scalar > 0, scale parameter in CFE disutil. of labor
+    labor_min    = scalar in (0, labor_max), lower bound of support of
+                   labor supply to be used in estimation of parameters
+    labor_max    = scalar in (labor_min, l_tilde), upper bound of
+                   support of labor supply to be used in estimation of
+                   parameters
+    labor_N      = integer > 30, number of points in support of labor
+                   supply to be used in estimation of parameters
+    labor_sup    = (labor_N,) vector, points in support of labor supply
+                   to be used in estimation of parameters
+    fit_args     = length 3 tuple, (Frisch, CFE_scale, labor_sup)
+    bnds_elp     = length 2 tuple, lower and upper bound pairs for b and
+                   upsilon elliptical disutility of labor parameters
+    ellip_params = length 9 dictionary, output from opt.minimize
+    b_ellip      = scalar > 0, scale parameter in elliptical disutility
+                   of labor function
+    upsilon      = scalar > 1, shape parameter in elliptical disutility
+                   of labor function
+    sumsq        = scalar > 0, sum of squared errors criterion from
+                   opt.minimize
+
+    FILES CREATED BY THIS FUNCTION:
+        images/EllipVsCFE_MargUtil.png
+
+    RETURNS: b_ellip, upsilon
+    --------------------------------------------------------------------
+    '''
+    Frisch, CFE_scale = cfe_params
+    labor_min = 0.05
+    labor_max = 0.95 * l_tilde
+    labor_N = 1000
+    labor_sup = np.linspace(labor_min, labor_max, labor_N)
+    fit_args = (Frisch, CFE_scale, l_tilde, labor_sup)
+    bnds_elp = ((1e-12, None), (1 + 1e-12, None))
+    ellip_params = opt.minimize(
+        MU_sumsq, ellip_init, args=(fit_args), method='L-BFGS-B',
+        bounds=bnds_elp)
+    b_ellip, upsilon = ellip_params.x
+    sumsq = ellip_params.fun
+    if ellip_params.success:
+        print('SUCCESSFULLY ESTIMATED ELLIPTICAL UTILITY.')
+        print('b=', b_ellip, ' upsilon=', upsilon, ' SumSq=', sumsq)
+
+        if graph:
+            '''
+            ------------------------------------------------------------
+            Plot marginal disutilities of labor for CFE and fitted
+            elliptical disutility of labor
+            ------------------------------------------------------------
+            cur_path    = string, path name of current directory
+            output_fldr = string, folder in current path to save files
+            output_dir  = string, total path of images folder
+            output_path = string, path of file name of figure to save
+            MU_ellip    = (labor_N,) vector, elliptical marginal
+                          utilities for values of labor supply
+            MU_CFE      = (labor_N,) vector, CFE marginal utilities for
+                          values of labor supply
+            ------------------------------------------------------------
+            '''
+            # Create directory if images folder does not already exist
+            cur_path = os.path.split(os.path.abspath(__file__))[0]
+            output_fldr = "images"
+            output_dir = os.path.join(cur_path, output_fldr)
+            if not os.access(output_dir, os.F_OK):
+                os.makedirs(output_dir)
+
+            # Plot steady-state consumption and savings distributions
+            MU_ellip = \
+                ((b_ellip / l_tilde) *
+                 ((labor_sup / l_tilde) ** (upsilon - 1)) *
+                 ((1 - ((labor_sup / l_tilde) ** upsilon)) **
+                 ((1 - upsilon) / upsilon)))
+            MU_CFE = CFE_scale * (labor_sup ** (1 / Frisch))
+            fig, ax = plt.subplots()
+            plt.plot(labor_sup, MU_ellip, label='Elliptical MU')
+            plt.plot(labor_sup, MU_CFE, label='CFE MU')
+            # for the minor ticks, use no labels; default NullFormatter
+            minorLocator = MultipleLocator(1)
+            ax.xaxis.set_minor_locator(minorLocator)
+            plt.grid(b=True, which='major', color='0.65', linestyle='-')
+            plt.title('CFE marginal utility versus fitted elliptical',
+                      fontsize=20)
+            plt.xlabel(r'Labor supply $n_{s,t}$')
+            plt.ylabel(r'Marginal disutility')
+            plt.xlim((0, l_tilde))
+            # plt.ylim((-1.0, 1.15 * (b_ss.max())))
+            plt.legend(loc='upper left')
+            output_path = os.path.join(output_dir,
+                                       'EllipVsCFE_MargUtil')
+            plt.savefig(output_path)
+            # plt.show()
+            plt.close()
+    else:
+        print('NOT SUCCESSFUL ESTIMATION OF ELLIPTICAL UTILITY')
+
+    return b_ellip, upsilon

--- a/DeBacker_Evans_simple/execute.py
+++ b/DeBacker_Evans_simple/execute.py
@@ -1,0 +1,304 @@
+'''
+------------------------------------------------------------------------
+This program runs the steady state solver as well as the time path
+iteration solution for the model with S-period lived agents and
+endogenous labor from Chapter 4 of the OG textbook.
+
+This Python script imports the following module(s):
+    SS.py
+    TPI.py
+    aggregates.py
+    elliputil.py
+    utilities.py
+
+This Python script calls the following function(s):
+    elp.fit_ellip_CFE()
+    ss.get_SS()
+    utils.compare_args()
+    aggr.get_K()
+    tpi.get_TPI()
+
+Files created by this script:
+    OUTPUT/SS/ss_vars.pkl
+    OUTPUT/SS/ss_args.pkl
+    OUTPUT/TPI/tpi_vars.pkl
+    OUTPUT/TPI/tpi_args.pkl
+------------------------------------------------------------------------
+'''
+# Import packages
+import numpy as np
+import pickle
+import os
+import SS as ss
+import TPI as tpi
+import aggregates as aggr
+import elliputil as elp
+import utilities as utils
+
+'''
+------------------------------------------------------------------------
+Declare parameters
+------------------------------------------------------------------------
+S              = integer in [3,80], number of periods an individual
+                 lives
+beta_annual    = scalar in (0,1), discount factor for one year
+beta           = scalar in (0,1), discount factor for each model period
+sigma          = scalar > 0, coefficient of relative risk aversion
+l_tilde        = scalar > 0, per-period time endowment for every agent
+chi_n_vec      = (S,) vector, values for chi^n_s
+A              = scalar > 0, total factor productivity parameter in
+                 firms' production function
+alpha          = scalar in (0,1), capital share of income
+delta_annual   = scalar in [0,1], one-year depreciation rate of capital
+delta          = scalar in [0,1], model-period depreciation rate of
+                 capital
+SS_solve       = boolean, =True if want to solve for steady-state
+                 solution, otherwise retrieve solutions from pickle
+SS_EulTol      = scalar > 0, tolerance level for steady-state inner-loop
+                 root finder
+SS_graphs      = boolean, =True if want graphs of steady-state objects
+SS_EulDiff     = boolean, =True if use simple differences in Euler
+                 errors. Otherwise, use percent deviation form.
+xi_SS          = scalar in (0, 1], SS updating parameter in outer-loop
+                 bisection method
+SS_maxiter     = integer >= 1, maximum iterations of outer-loop steady-
+                 state bisection method
+T1             = integer > S, number of time periods until steady state
+                 is assumed to be reached
+T2             = integer > T1, number of time periods after which
+                 steady state is forced in TPI
+TPI_solve      = boolean, =True if want to solve TPI after solving SS
+TPI_OutTol     = scalar > 0, tolerance level for outer-loop bisection
+                 method in TPI
+TPI_InTol      = scalar > 0, tolerance level for inner-loop root finder
+                 in each iteration of TPI
+maxiter_TPI    = integer >= 1, Maximum number of iterations for TPI
+xi_TPI         = scalar in (0,1], TPI path updating parameter
+TPI_graphs     = boolean, =True if want graphs of TPI objects
+TPI_EulDiff    = boolean, =True if want difference version of Euler
+                 errors beta*(1+r)*u'(c2) - u'(c1), =False if want ratio
+                 version [beta*(1+r)*u'(c2)]/[u'(c1)] - 1
+------------------------------------------------------------------------
+'''
+# Household parameters
+S = int(80)
+beta_annual = 0.96
+beta = beta_annual ** (80 / S)
+sigma = 2.5
+l_tilde = 1.0
+chi_n_vec = 1.0 * np.ones(S)
+# Firm parameters
+A = 1.0
+alpha = 0.35
+delta_annual = 0.05
+delta = 1 - ((1 - delta_annual) ** (80 / S))
+# SS parameters
+SS_solve = True
+SS_BsctTol = 1e-13
+SS_EulTol = 1e-13
+SS_graphs = True
+SS_EulDiff = True
+xi_SS = 0.15
+SS_maxiter = 200
+# TPI parameters
+T1 = int(round(2.0 * S))
+T2 = int(round(2.5 * S))
+TPI_solve = True
+TPI_OutTol = 1e-7
+TPI_InTol = 1e-13
+maxiter_TPI = 200
+xi_TPI = 0.30
+TPI_graphs = True
+TPI_EulDiff = True
+
+'''
+------------------------------------------------------------------------
+Fit elliptical utility function to constant Frisch elasticity (CFE)
+disutility of labor function by matching marginal utilities along the
+support of leisure
+------------------------------------------------------------------------
+ellip_graph  = Boolean, =True if want to save plot of fit
+b_ellip_init = scalar > 0, initial guess for b
+upsilon_init = scalar > 1, initial guess for upsilon
+ellip_init   = (2,) vector, initial guesses for b and upsilon
+Frisch_elast = scalar > 0, Frisch elasticity of labor supply for CFE
+               disutility of labor
+CFE_scale    = scalar > 0, scale parameter for CFE disutility of labor
+cfe_params   = (2,) vector, values for (Frisch, CFE_scale)
+b_ellip      = scalar > 0, fitted value of b for elliptical disutility
+               of labor
+upsilon      = scalar > 1, fitted value of upsilon for elliptical
+               disutility of labor
+------------------------------------------------------------------------
+'''
+ellip_graph = False
+b_ellip_init = 1.0
+upsilon_init = 2.0
+ellip_init = np.array([b_ellip_init, upsilon_init])
+Frisch_elast = 0.9
+CFE_scale = 1.0
+cfe_params = np.array([Frisch_elast, CFE_scale])
+b_ellip, upsilon = elp.fit_ellip_CFE(ellip_init, cfe_params, l_tilde,
+                                     ellip_graph)
+
+'''
+------------------------------------------------------------------------
+Solve for the steady-state solution
+------------------------------------------------------------------------
+cur_path       = string, current file path of this script
+ss_output_fldr = string, cur_path extension of SS output folder path
+ss_output_dir  = string, full path name of SS output folder
+ss_outputfile  = string, path name of file for SS output objects
+ss_paramsfile  = string, path name of file for SS parameter objects
+ss_args        = length 15 tuple, arguments to pass in to ss.get_SS()
+rss_init       = scalar > -delta, initial guess for r_ss
+c1_init        = scalar > 0, initial guess for c1
+init_vals      = length 2 tuple, initial guesses (r, c1) to be passed
+                 in to ss.get_SS
+ss_output      = length 14 dict, steady-state objects {n_ss, b_ss, c_ss,
+                 b_Sp1_ss, w_ss, r_ss, K_ss, L_ss, Y_ss, C_ss, n_err_ss,
+                 b_err_ss, RCerr_ss, ss_time}
+ss_vars_exst   = boolean, =True if ss_vars.pkl exists
+ss_args_exst   = boolean, =True if ss_args.pkl exists
+err_msg        = string, error message
+prev_ss_args   = length 12 tuple, previous arguments used to produce
+                 saved steady-state output
+args_same      = boolean, =True if ss_args == prev_ss_args
+------------------------------------------------------------------------
+'''
+# Create OUTPUT/SS directory if does not already exist
+cur_path = os.path.split(os.path.abspath(__file__))[0]
+ss_output_fldr = 'OUTPUT/SS'
+ss_output_dir = os.path.join(cur_path, ss_output_fldr)
+if not os.access(ss_output_dir, os.F_OK):
+    os.makedirs(ss_output_dir)
+ss_outputfile = os.path.join(ss_output_dir, 'ss_vars.pkl')
+ss_paramsfile = os.path.join(ss_output_dir, 'ss_args.pkl')
+
+# Compute steady-state solution
+ss_args = (S, beta, sigma, l_tilde, b_ellip, upsilon, chi_n_vec, A,
+           alpha, delta, SS_BsctTol, SS_EulTol, SS_EulDiff, xi_SS,
+           SS_maxiter)
+
+if SS_solve:
+    print('BEGIN EQUILIBRIUM STEADY-STATE COMPUTATION')
+    rss_init = 0.06
+    c1_init = 0.1
+    init_vals = (rss_init, c1_init)
+
+    print('Solving SS outer loop using bisection method on r.')
+    ss_output = ss.get_SS(init_vals, ss_args, SS_graphs)
+
+    # Save ss_output as pickle
+    pickle.dump(ss_output, open(ss_outputfile, 'wb'))
+    pickle.dump(ss_args, open(ss_paramsfile, 'wb'))
+
+# Don't compute steady-state, get it from pickle
+else:
+    # Make sure that the SS output files exist
+    ss_vars_exst = os.path.exists(ss_outputfile)
+    ss_args_exst = os.path.exists(ss_paramsfile)
+    if (not ss_vars_exst) or (not ss_args_exst):
+        # If the files don't exist, stop the program and run the steady-
+        # state solution first
+        err_msg = ('ERROR: The SS output files do not exist and ' +
+                   'SS_solve=False. Must set SS_solve=True and ' +
+                   'compute steady-state solution.')
+        raise RuntimeError(err_msg)
+    else:
+        # If the files do exist, make sure that none of the parameters
+        # changed from the parameters used in the solution for the saved
+        # steady-state pickle
+        prev_ss_args = pickle.load(open(ss_paramsfile, 'rb'))
+
+        args_same = utils.compare_args(ss_args, prev_ss_args)
+        if args_same:
+            # If none of the parameters changed, use saved pickle
+            print('RETRIEVE STEADY-STATE SOLUTIONS FROM FILE')
+            ss_output = pickle.load(open(ss_outputfile, 'rb'))
+        else:
+            # If any of the parameters changed, end the program and
+            # compute the steady-state solution
+            err_msg = ('ERROR: Current ss_args are not equal to the ' +
+                       'ss_args that produced ss_output. Must solve ' +
+                       'for SS before solving transition path. Set ' +
+                       'SS_solve=True.')
+            raise RuntimeError(err_msg)
+
+'''
+------------------------------------------------------------------------
+Solve for the transition path equilibrium by time path iteration (TPI)
+------------------------------------------------------------------------
+tpi_output_fldr = string, cur_path extension of TPI output folder path
+tpi_output_dir  = string, full path name of TPI output folder
+tpi_outputfile  = string, path name of file for TPI output objects
+tpi_paramsfile  = string, path name of file for TPI parameter objects
+r_ss            = scalar > 0, steady-state aggregate interest rate
+K_ss            = scalar > 0, steady-state aggregate capital stock
+L_ss            = scalar > 0, steady-state aggregate labor
+C_ss            = scalar > 0, steady-state aggregate consumption
+b_ss            = (S,) vector, steady-state savings distribution
+                  (b1, b2,... bS)
+n_ss            = (S,) vector, steady-state labor supply distribution
+                  (n1, n2,... nS)
+init_wgts       = (S,) vector, weights representing the factor by which
+                  the initial wealth distribution differs from the
+                  steady-state wealth distribution
+bvec1           = (S,) vector, initial period savings distribution
+K1              = scalar, initial period aggregate capital stock
+K1_cstr         = boolean, =True if K1 <= 0
+tpi_params      = length 23 tuple, args to pass into c7tpf.get_TPI()
+tpi_output      = length 14 dictionary, {cpath, npath, bpath, wpath,
+                  rpath, Kpath, Lpath, Ypath, Cpath, bSp1_err_path,
+                  b_err_path, n_err_path, RCerrPath, tpi_time}
+tpi_args        = length 24 tuple, args that were passed in to get_TPI()
+------------------------------------------------------------------------
+'''
+if TPI_solve:
+    print('BEGIN EQUILIBRIUM TRANSITION PATH COMPUTATION')
+
+    # Create OUTPUT/TPI directory if does not already exist
+    cur_path = os.path.split(os.path.abspath(__file__))[0]
+    tpi_output_fldr = 'OUTPUT/TPI'
+    tpi_output_dir = os.path.join(cur_path, tpi_output_fldr)
+    if not os.access(tpi_output_dir, os.F_OK):
+        os.makedirs(tpi_output_dir)
+    tpi_outputfile = os.path.join(tpi_output_dir, 'tpi_vars.pkl')
+    tpi_paramsfile = os.path.join(tpi_output_dir, 'tpi_args.pkl')
+
+    r_ss = ss_output['r_ss']
+    K_ss = ss_output['K_ss']
+    L_ss = ss_output['L_ss']
+    C_ss = ss_output['C_ss']
+    b_ss = ss_output['b_ss']
+    n_ss = ss_output['n_ss']
+
+    # Choose initial period distribution of wealth (bvec1), which
+    # determines initial period aggregate capital stock
+    init_wgts = ((1.5 - 0.87) / (S - 1) *
+                 (np.linspace(1, S, S) - 1) + 0.87)
+    bvec1 = init_wgts * b_ss
+    # bvec1 = b_ss
+
+    # Make sure init. period distribution is feasible in terms of K
+    K1, K1_cstr = aggr.get_K(bvec1)
+
+    # If initial bvec1 is not feasible end program
+    if K1_cstr:
+        print('Initial savings distribution is not feasible because ' +
+              'K1<=0. Some element(s) of bvec1 must increase.')
+    else:
+        tpi_params = (S, T1, T2, beta, sigma, l_tilde, b_ellip, upsilon,
+                      chi_n_vec, A, alpha, delta, r_ss, K_ss, L_ss, C_ss,
+                      b_ss, n_ss, maxiter_TPI, TPI_OutTol, TPI_InTol,
+                      TPI_EulDiff, xi_TPI)
+        tpi_output = tpi.get_TPI(bvec1, tpi_params, TPI_graphs)
+
+        tpi_args = (S, T1, T2, beta, sigma, l_tilde, b_ellip, upsilon,
+                    chi_n_vec, A, alpha, delta, r_ss, K_ss, L_ss, C_ss,
+                    b_ss, n_ss, maxiter_TPI, TPI_OutTol, TPI_InTol,
+                    TPI_EulDiff, xi_TPI, bvec1)
+
+        # Save tpi_output as pickle
+        pickle.dump(tpi_output, open(tpi_outputfile, 'wb'))
+        pickle.dump(tpi_args, open(tpi_paramsfile, 'wb'))

--- a/DeBacker_Evans_simple/firms.py
+++ b/DeBacker_Evans_simple/firms.py
@@ -1,0 +1,85 @@
+'''
+------------------------------------------------------------------------
+This module contains the functions that generate the variables
+associated with firms' optimization in the steady-state or in the
+transition path of the overlapping generations model with S-period lived
+agents and endogenous labor supply from Chapter 7 of the OG textbook.
+
+This Python module imports the following module(s): None
+
+This Python module defines the following function(s):
+    get_w()
+    get_r()
+------------------------------------------------------------------------
+'''
+# Import packages
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def get_w(r, params):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state wage w or time path of wages w_t
+    --------------------------------------------------------------------
+    INPUTS:
+    r      = scalar > -delta or (T+S-2,) vector, steady-state aggregate
+             interest rate or time path of the interest rate
+    params = length 3 tuple, (A, alpha, delta)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    A     = scalar > 0, total factor productivity
+    alpha = scalar in (0, 1), capital share of income
+    delta = scalar in (0, 1), per period depreciation rate
+    w     = scalar > 0 or (T+S-2) vector, steady-state wage or time path
+            of wage
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: w
+    --------------------------------------------------------------------
+    '''
+    A, alpha, delta = params
+    w = (1 - alpha) * A * (((alpha * A) / (r + delta)) **
+                           (alpha / (1 - alpha)))
+
+    return w
+
+
+def get_r(K, L, params):
+    '''
+    --------------------------------------------------------------------
+    Solve for steady-state interest rate r or time path of interest
+    rates r_t
+    --------------------------------------------------------------------
+    INPUTS:
+    K      = scalar > 0 or (T+S-2,) vector, steady-state aggregate
+             capital stock or time path of the aggregate capital stock
+    L      = scalar > 0 or (T+S-2,) vector, steady-state aggregate
+             labor or time path of aggregate labor
+    params = length 3 tuple, (A, alpha, delta)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    A     = scalar > 0, total factor productivity
+    alpha = scalar in (0, 1), capital share of income
+    delta = scalar in (0, 1), per period depreciation rate
+    r     = scalar > 0 or (T+S-2) vector, steady-state interest rate or
+            time path of interest rate
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: r
+    --------------------------------------------------------------------
+    '''
+    A, alpha, delta = params
+    r = alpha * A * ((L / K) ** (1 - alpha)) - delta
+
+    return r

--- a/DeBacker_Evans_simple/households.py
+++ b/DeBacker_Evans_simple/households.py
@@ -1,0 +1,561 @@
+'''
+------------------------------------------------------------------------
+This module contains the functions that generate the variables
+associated with households' optimization in the steady-state or in the
+transition path of the overlapping generations model with S-period lived
+agents and endogenous labor supply from Chapter 7 of the OG textbook.
+
+This Python module imports the following module(s): None
+
+This Python module defines the following function(s):
+    get_cons()
+    MU_c_stitch()
+    MDU_n_stitch()
+    get_n_errors()
+    get_b_errors()
+    get_cnb_vecs()
+    c1_bSp1err()
+------------------------------------------------------------------------
+'''
+# Import packages
+import numpy as np
+import scipy.optimize as opt
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+import os
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def get_cons(r, w, b, b_sp1, n):
+    '''
+    --------------------------------------------------------------------
+    Calculate household consumption given prices, labor supply, current
+    wealth, and savings
+    --------------------------------------------------------------------
+    INPUTS:
+    r     = scalar or (p,) vector, current interest rate or time path of
+            interest rates over remaining life periods
+    w     = scalar or (p,) vector, current wage or time path of wages
+            over remaining life periods
+    b     = scalar or (p,) vector, current period wealth or time path of
+            current period wealths over remaining life periods
+    b_sp1 = scalar or (p,) vector, savings for next period or time path
+            of savings for next period over remaining life periods
+    n     = scalar or (p,) vector, current labor supply or time path of
+            labor supply over remaining life periods
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    cons = scalar or (p,) vector, current consumption or time path of
+           consumption over remaining life periods
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: cons
+    --------------------------------------------------------------------
+    '''
+    cons = ((1 + r) * b) + (w * n) - b_sp1
+
+    return cons
+
+
+def MU_c_stitch(cvec, sigma, graph=False):
+    '''
+    --------------------------------------------------------------------
+    Generate marginal utility(ies) of consumption with CRRA consumption
+    utility and stitched function at lower bound such that the new
+    hybrid function is defined over all consumption on the real
+    line but the function has similar properties to the Inada condition.
+
+    u'(c) = c ** (-sigma) if c >= epsilon
+          = g'(c) = 2 * b2 * c + b1 if c < epsilon
+
+        such that g'(epsilon) = u'(epsilon)
+        and g''(epsilon) = u''(epsilon)
+
+        u(c) = (c ** (1 - sigma) - 1) / (1 - sigma)
+        g(c) = b2 * (c ** 2) + b1 * c + b0
+    --------------------------------------------------------------------
+    INPUTS:
+    cvec  = scalar or (p,) vector, individual consumption value or
+            lifetime consumption over p consecutive periods
+    sigma = scalar >= 1, coefficient of relative risk aversion for CRRA
+            utility function: (c**(1-sigma) - 1) / (1 - sigma)
+    graph = boolean, =True if want plot of stitched marginal utility of
+            consumption function
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    epsilon    = scalar > 0, positive value close to zero
+    c_s        = scalar, individual consumption
+    c_s_cnstr  = boolean, =True if c_s < epsilon
+    b1         = scalar, intercept value in linear marginal utility
+    b2         = scalar, slope coefficient in linear marginal utility
+    MU_c       = scalar or (p,) vector, marginal utility of consumption
+                 or vector of marginal utilities of consumption
+    p          = integer >= 1, number of periods remaining in lifetime
+    cvec_cnstr = (p,) boolean vector, =True for values of cvec < epsilon
+
+    FILES CREATED BY THIS FUNCTION:
+        MU_c_stitched.png
+
+    RETURNS: MU_c
+    --------------------------------------------------------------------
+    '''
+    epsilon = 0.0001
+    if np.ndim(cvec) == 0:
+        c_s = cvec
+        c_s_cnstr = c_s < epsilon
+        if c_s_cnstr:
+            b2 = (-sigma * (epsilon ** (-sigma - 1))) / 2
+            b1 = (epsilon ** (-sigma)) - 2 * b2 * epsilon
+            MU_c = 2 * b2 * c_s + b1
+        else:
+            MU_c = c_s ** (-sigma)
+    elif np.ndim(cvec) == 1:
+        p = cvec.shape[0]
+        cvec_cnstr = cvec < epsilon
+        MU_c = np.zeros(p)
+        MU_c[~cvec_cnstr] = cvec[~cvec_cnstr] ** (-sigma)
+        b2 = (-sigma * (epsilon ** (-sigma - 1))) / 2
+        b1 = (epsilon ** (-sigma)) - 2 * b2 * epsilon
+        MU_c[cvec_cnstr] = 2 * b2 * cvec[cvec_cnstr] + b1
+
+    if graph:
+        '''
+        ----------------------------------------------------------------
+        cur_path    = string, path name of current directory
+        output_fldr = string, folder in current path to save files
+        output_dir  = string, total path of images folder
+        output_path = string, path of file name of figure to be saved
+        cvec_CRRA   = (1000,) vector, support of c including values
+                      between 0 and epsilon
+        MU_CRRA     = (1000,) vector, CRRA marginal utility of
+                      consumption
+        cvec_stitch = (500,) vector, stitched support of consumption
+                      including negative values up to epsilon
+        MU_stitch   = (500,) vector, stitched marginal utility of
+                      consumption
+        ----------------------------------------------------------------
+        '''
+        # Create directory if images directory does not already exist
+        cur_path = os.path.split(os.path.abspath(__file__))[0]
+        output_fldr = "images"
+        output_dir = os.path.join(cur_path, output_fldr)
+        if not os.access(output_dir, os.F_OK):
+            os.makedirs(output_dir)
+
+        # Plot steady-state consumption and savings distributions
+        cvec_CRRA = np.linspace(epsilon / 2, epsilon * 3, 1000)
+        MU_CRRA = cvec_CRRA ** (-sigma)
+        cvec_stitch = np.linspace(-0.00005, epsilon, 500)
+        MU_stitch = 2 * b2 * cvec_stitch + b1
+        fig, ax = plt.subplots()
+        plt.plot(cvec_CRRA, MU_CRRA, ls='solid', label='$u\'(c)$: CRRA')
+        plt.plot(cvec_stitch, MU_stitch, ls='dashed', color='red',
+                 label='$g\'(c)$: stitched')
+        # for the minor ticks, use no labels; default NullFormatter
+        minorLocator = MultipleLocator(1)
+        ax.xaxis.set_minor_locator(minorLocator)
+        plt.grid(b=True, which='major', color='0.65', linestyle='-')
+        plt.title('Marginal utility of consumption with stitched ' +
+                  'function', fontsize=14)
+        plt.xlabel(r'Consumption $c$')
+        plt.ylabel(r'Marginal utility $u\'(c)$')
+        plt.xlim((-0.00005, epsilon * 3))
+        # plt.ylim((-1.0, 1.15 * (b_ss.max())))
+        plt.legend(loc='upper right')
+        output_path = os.path.join(output_dir, "MU_c_stitched")
+        plt.savefig(output_path)
+        # plt.show()
+
+    return MU_c
+
+
+def MDU_n_stitch(nvec, params, graph=False):
+    '''
+    --------------------------------------------------------------------
+    Generate marginal disutility(ies) of labor with elliptical
+    disutility of labor function and stitched functions at lower bound
+    and upper bound of labor supply such that the new hybrid function is
+    defined over all labor supply on the real line but the function has
+    similar properties to the Inada conditions at the upper and lower
+    bounds.
+
+    v'(n) = (b / l_tilde) * ((n / l_tilde) ** (upsilon - 1)) *
+            ((1 - ((n / l_tilde) ** upsilon)) ** ((1-upsilon)/upsilon))
+            if n >= eps_low <= n <= eps_high
+          = g_low'(n)  = 2 * b2 * n + b1 if n < eps_low
+          = g_high'(n) = 2 * d2 * n + d1 if n > eps_high
+
+        such that g_low'(eps_low) = u'(eps_low)
+        and g_low''(eps_low) = u''(eps_low)
+        and g_high'(eps_high) = u'(eps_high)
+        and g_high''(eps_high) = u''(eps_high)
+
+        v(n) = -b *(1 - ((n/l_tilde) ** upsilon)) ** (1/upsilon)
+        g_low(n)  = b2 * (n ** 2) + b1 * n + b0
+        g_high(n) = d2 * (n ** 2) + d1 * n + d0
+    --------------------------------------------------------------------
+    INPUTS:
+    nvec   = scalar or (p,) vector, labor supply value or labor supply
+             values over remaining periods of lifetime
+    params = length 3 tuple, (l_tilde, b_ellip, upsilon)
+    graph  = Boolean, =True if want plot of stitched marginal disutility
+             of labor function
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    l_tilde       = scalar > 0, time endowment for each agent each per
+    b_ellip       = scalar > 0, scale parameter for elliptical utility
+                    of leisure function
+    upsilon       = scalar > 1, shape parameter for elliptical utility
+                    of leisure function
+    eps_low       = scalar > 0, positive value close to zero
+    eps_high      = scalar > 0, positive value just less than l_tilde
+    n_s           = scalar, individual labor supply
+    n_s_low       = boolean, =True for n_s < eps_low
+    n_s_high      = boolean, =True for n_s > eps_high
+    n_s_uncstr    = boolean, =True for n_s >= eps_low and
+                    n_s <= eps_high
+    MDU_n         = scalar or (p,) vector, marginal disutility or
+                    marginal utilities of labor supply
+    b1            = scalar, intercept value in linear marginal
+                    disutility of labor at lower bound
+    b2            = scalar, slope coefficient in linear marginal
+                    disutility of labor at lower bound
+    d1            = scalar, intercept value in linear marginal
+                    disutility of labor at upper bound
+    d2            = scalar, slope coefficient in linear marginal
+                    disutility of labor at upper bound
+    p             = integer >= 1, number of periods remaining in life
+    nvec_s_low    = boolean, =True for n_s < eps_low
+    nvec_s_high   = boolean, =True for n_s > eps_high
+    nvec_s_uncstr = boolean, =True for n_s >= eps_low and
+                    n_s <= eps_high
+
+    FILES CREATED BY THIS FUNCTION:
+        MDU_n_stitched.png
+
+    RETURNS: MDU_n
+    --------------------------------------------------------------------
+    '''
+    l_tilde, b_ellip, upsilon = params
+    eps_low = 0.000001
+    eps_high = l_tilde - 0.000001
+    # This if is for when nvec is a scalar
+    if np.ndim(nvec) == 0:
+        n_s = nvec
+        n_s_low = n_s < eps_low
+        n_s_high = n_s > eps_high
+        n_s_uncstr = (n_s >= eps_low) and (n_s <= eps_high)
+        if n_s_uncstr:
+            MDU_n = \
+                ((b_ellip / l_tilde) * ((n_s / l_tilde) **
+                 (upsilon - 1)) * ((1 - ((n_s / l_tilde) ** upsilon)) **
+                 ((1 - upsilon) / upsilon)))
+        elif n_s_low:
+            b2 = (0.5 * b_ellip * (l_tilde ** (-upsilon)) *
+                  (upsilon - 1) * (eps_low ** (upsilon - 2)) *
+                  ((1 - ((eps_low / l_tilde) ** upsilon)) **
+                  ((1 - upsilon) / upsilon)) *
+                  (1 + ((eps_low / l_tilde) ** upsilon) *
+                  ((1 - ((eps_low / l_tilde) ** upsilon)) ** (-1))))
+            b1 = ((b_ellip / l_tilde) * ((eps_low / l_tilde) **
+                  (upsilon - 1)) *
+                  ((1 - ((eps_low / l_tilde) ** upsilon)) **
+                  ((1 - upsilon) / upsilon)) - (2 * b2 * eps_low))
+            MDU_n = 2 * b2 * n_s + b1
+        elif n_s_high:
+            d2 = (0.5 * b_ellip * (l_tilde ** (-upsilon)) *
+                  (upsilon - 1) * (eps_high ** (upsilon - 2)) *
+                  ((1 - ((eps_high / l_tilde) ** upsilon)) **
+                  ((1 - upsilon) / upsilon)) *
+                  (1 + ((eps_high / l_tilde) ** upsilon) *
+                  ((1 - ((eps_high / l_tilde) ** upsilon)) ** (-1))))
+            d1 = ((b_ellip / l_tilde) * ((eps_high / l_tilde) **
+                  (upsilon - 1)) *
+                  ((1 - ((eps_high / l_tilde) ** upsilon)) **
+                  ((1 - upsilon) / upsilon)) - (2 * d2 * eps_high))
+            MDU_n = 2 * d2 * n_s + d1
+    # This if is for when nvec is a one-dimensional vector
+    elif np.ndim(nvec) == 1:
+        p = nvec.shape[0]
+        nvec_low = nvec < eps_low
+        nvec_high = nvec > eps_high
+        nvec_uncstr = np.logical_and(~nvec_low, ~nvec_high)
+        MDU_n = np.zeros(p)
+        MDU_n[nvec_uncstr] = (
+            (b_ellip / l_tilde) *
+            ((nvec[nvec_uncstr] / l_tilde) ** (upsilon - 1)) *
+            ((1 - ((nvec[nvec_uncstr] / l_tilde) ** upsilon)) **
+             ((1 - upsilon) / upsilon)))
+        b2 = (0.5 * b_ellip * (l_tilde ** (-upsilon)) * (upsilon - 1) *
+              (eps_low ** (upsilon - 2)) *
+              ((1 - ((eps_low / l_tilde) ** upsilon)) **
+              ((1 - upsilon) / upsilon)) *
+              (1 + ((eps_low / l_tilde) ** upsilon) *
+              ((1 - ((eps_low / l_tilde) ** upsilon)) ** (-1))))
+        b1 = ((b_ellip / l_tilde) * ((eps_low / l_tilde) **
+              (upsilon - 1)) *
+              ((1 - ((eps_low / l_tilde) ** upsilon)) **
+              ((1 - upsilon) / upsilon)) - (2 * b2 * eps_low))
+        MDU_n[nvec_low] = 2 * b2 * nvec[nvec_low] + b1
+        d2 = (0.5 * b_ellip * (l_tilde ** (-upsilon)) * (upsilon - 1) *
+              (eps_high ** (upsilon - 2)) *
+              ((1 - ((eps_high / l_tilde) ** upsilon)) **
+              ((1 - upsilon) / upsilon)) *
+              (1 + ((eps_high / l_tilde) ** upsilon) *
+              ((1 - ((eps_high / l_tilde) ** upsilon)) ** (-1))))
+        d1 = ((b_ellip / l_tilde) * ((eps_high / l_tilde) **
+              (upsilon - 1)) *
+              ((1 - ((eps_high / l_tilde) ** upsilon)) **
+              ((1 - upsilon) / upsilon)) - (2 * d2 * eps_high))
+        MDU_n[nvec_high] = 2 * d2 * nvec[nvec_high] + d1
+
+    if graph:
+        '''
+        ----------------------------------------------------------------
+        cur_path    = string, path name of current directory
+        output_fldr = string, folder in current path to save files
+        output_dir  = string, total path of images folder
+        output_path = string, path of file name of figure to be saved
+        nvec_ellip  = (1000,) vector, support of n including values
+                      between 0 and eps_low and between eps_high and
+                      l_tilde
+        MU_CRRA     = (1000,) vector, CRRA marginal utility of
+                      consumption
+        cvec_stitch = (500,) vector, stitched support of consumption
+                      including negative values up to epsilon
+        MU_stitch   = (500,) vector, stitched marginal utility of
+                      consumption
+        ----------------------------------------------------------------
+        '''
+        # Create directory if images directory does not already exist
+        cur_path = os.path.split(os.path.abspath(__file__))[0]
+        output_fldr = "images"
+        output_dir = os.path.join(cur_path, output_fldr)
+        if not os.access(output_dir, os.F_OK):
+            os.makedirs(output_dir)
+
+        # Plot steady-state consumption and savings distributions
+        nvec_ellip = np.linspace(eps_low / 2, eps_high +
+                                 ((l_tilde - eps_high) / 5), 1000)
+        MDU_ellip = (
+            (b_ellip / l_tilde) *
+            ((nvec_ellip / l_tilde) ** (upsilon - 1)) *
+            ((1 - ((nvec_ellip / l_tilde) ** upsilon)) **
+             ((1 - upsilon) / upsilon)))
+        n_stitch_low = np.linspace(-0.05, eps_low, 500)
+        MDU_stitch_low = 2 * b2 * n_stitch_low + b1
+        n_stitch_high = np.linspace(eps_high, l_tilde + 0.000005, 500)
+        MDU_stitch_high = 2 * d2 * n_stitch_high + d1
+        fig, ax = plt.subplots()
+        plt.plot(nvec_ellip, MDU_ellip, ls='solid', color='black',
+                 label='$v\'(n)$: Elliptical')
+        plt.plot(n_stitch_low, MDU_stitch_low, ls='dashed', color='red',
+                 label='$g\'(n)$: low stitched')
+        plt.plot(n_stitch_high, MDU_stitch_high, ls='dotted',
+                 color='blue', label='$g\'(n)$: high stitched')
+        # for the minor ticks, use no labels; default NullFormatter
+        minorLocator = MultipleLocator(1)
+        ax.xaxis.set_minor_locator(minorLocator)
+        plt.grid(b=True, which='major', color='0.65', linestyle='-')
+        plt.title('Marginal utility of consumption with stitched ' +
+                  'function', fontsize=14)
+        plt.xlabel(r'Labor $n$')
+        plt.ylabel(r'Marginal disutility $v\'(n)$')
+        plt.xlim((-0.05, l_tilde + 0.01))
+        # plt.ylim((-1.0, 1.15 * (b_ss.max())))
+        plt.legend(loc='upper left')
+        output_path = os.path.join(output_dir, "MDU_n_stitched")
+        plt.savefig(output_path)
+        # plt.show()
+
+    return MDU_n
+
+
+def get_n_errors(nvec, *args):
+    '''
+    --------------------------------------------------------------------
+    Generates vector of static Euler errors that characterize the
+    optimal lifetime labor supply decision. Because this function is
+    used for solving for lifetime decisions in both the steady-state and
+    in the transition path, lifetimes will be of varying length.
+    Lifetimes in the steady-state will be S periods. Lifetimes in the
+    transition path will be p in [2, S] periods
+    --------------------------------------------------------------------
+    INPUTS:
+    nvec = (p,) vector, distribution of labor supply by age n_p
+    args = either length 8 tuple or length 10 tuple, is (w, sigma,
+           l_tilde, chi_n_vec, b_ellip, upsilon, diff, cvec) in most
+           cases. In the time path for the age-S individuals in period
+           1, the tuple is (wpath, sigma, l_tilde, chi_n_vec, b_ellip,
+           upsilon, diff, rpath, b_s_vec, b_sp1_vec)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        MU_c_stitch()
+        MDU_n_stitch()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    w           = scalar > 0 or (p,) vector, steady-state wage or time
+                  path of wage
+    sigma       = scalar > 0, coefficient of relative risk aversion
+    l_tilde     = scalar > 0, time endowment of each agent in each per
+    chi_n_vec   = (p,) vector, values for chi^n_p
+    b_ellip     = scalar > 0, fitted value of b for elliptical
+                  disutility of labor
+    upsilon     = scalar > 1, fitted value of upsilon for elliptical
+                  disutility of labo
+    diff        = Boolean, =True if use simple difference Euler errors.
+                  Use percent difference errors otherwise
+    cvec        = (p,) vector, distribution of consumption by age c_p
+    mu_c        = (p,) vector, marginal utility of consumption
+    mdun_params = length 3 tuple, (l_tilde, b_ellip, upsilon)
+    mdu_n       = (p,) vector, marginal disutility of labor supply
+    n_errors    = (p,) vector, Euler errors characterizing optimal labor
+                  supply nvec
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: n_errors
+    --------------------------------------------------------------------
+    '''
+    if len(args) == 8:
+        # Steady-state, and almost all of TPI solutions pass in cvec.
+        # args is length 8
+        (wpath, sigma, l_tilde, chi_n_vec, b_ellip, upsilon, diff,
+            cvec) = args
+
+    else:
+        # solving for n_{S,1} in TPI does not pass in cvec, but passes
+        # in rpath, b_s_vec, and b_sp1_vec instead. args is length 10
+        (wpath, sigma, l_tilde, chi_n_vec, b_ellip, upsilon, diff,
+            rpath, b_s_vec, b_sp1_vec) = args
+        cvec = get_cons(rpath, wpath, b_s_vec, b_sp1_vec, nvec)
+
+    mu_c = MU_c_stitch(cvec, sigma)
+    mdun_params = (l_tilde, b_ellip, upsilon)
+    mdu_n = MDU_n_stitch(nvec, mdun_params)
+    if diff:
+        n_errors = (wpath * mu_c) - chi_n_vec * mdu_n
+    else:
+        n_errors = ((wpath * mu_c) / (chi_n_vec * mdu_n)) - 1
+
+    return n_errors
+
+
+def get_b_errors(cvec, *args):
+    '''
+    --------------------------------------------------------------------
+    Generates vector of dynamic Euler errors that characterize the
+    optimal lifetime savings decision. Because this function is used for
+    solving for lifetime decisions in both the steady-state and in the
+    transition path, lifetimes will be of varying length. Lifetimes in
+    the steady-state will be S periods. Lifetimes in the transition path
+    will be p in [2, S] periods
+    --------------------------------------------------------------------
+    INPUTS:
+    cvec = (p,) vector, distribution of consumption by age c_p
+    r    = scalar > 0 or (p-1,) vector, steady-state interest rate or
+           time path of interest rates
+    args = length 3 tuple, (beta, sigma, diff)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        MU_c_stitch()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    beta     = scalar in (0,1), discount factor
+    sigma    = scalar > 0, coefficient of relative risk aversion
+    diff     = boolean, =True if use simple difference Euler errors. Use
+               percent difference errors otherwise.
+    mu_c     = (p-1,) vector, marginal utility of current consumption
+    mu_cp1   = (p-1,) vector, marginal utility of next period consumpt'n
+    b_errors = (p-1,) vector, Euler errors characterizing optimal
+               savings bvec
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: b_errors
+    --------------------------------------------------------------------
+    '''
+    (r, beta, sigma, diff) = args
+    mu_c = MU_c_stitch(cvec[:-1], sigma)
+    mu_cp1 = MU_c_stitch(cvec[1:], sigma)
+
+    if diff:
+        b_errors = (beta * (1 + r) * mu_cp1) - mu_c
+    else:
+        b_errors = ((beta * (1 + r) * mu_cp1) / mu_c) - 1
+
+    return b_errors
+
+
+def bn_errors(bn_vec, *args):
+    '''
+    --------------------------------------------------------------------
+    Computes labor supply and savings Euler errors for given b_{s+1} and
+    n_s vectors and given the path of interest rates and wages
+    --------------------------------------------------------------------
+    INPUTS:
+    bn_vec = (2p-1,) vector, values for remaining life n_s and b_{s+1}
+    args   = length 11 tuple, (rpath, wpath, b_init, p, beta, sigma,
+             l_tilde, chi_n_vec, b_ellip, upsilon, diff)
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION:
+        get_cons()
+        get_n_errors()
+        get_b_errors()
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    rpath     = (p,) vector, time path of interest rates over remaining
+                lifetime
+    wpath     = (p,) vector, time path of wages over remaining lifetime
+    b_init    = scalar, initial wealth
+    p         = integer >= 1, number of periods remaining in lifetime
+    beta      = scalar in (0,1), discount factor
+    sigma     = scalar > 0, coefficient of relative risk aversion
+    l_tilde   = scalar > 0, per-period time endowment for every agent
+    chi_n_vec = (p,) vector, values for chi^n_s for remaining lifetime
+    b_ellip   = scalar > 0, fitted value of b for elliptical disutility
+                of labor
+    upsilon   = scalar > 1, fitted value of upsilon for elliptical
+                disutility of labor
+    b_sp1_vec = (p-1,) vector, savings over remaining lifetime
+    n_vec     = (p,) vector, labor supply over remaining lifetime
+    b_s_vec   = (p-1,) vector, wealth over remaining lifetime
+    n_args    = length 8 tuple, args to pass into hh.get_n_errors()
+    n_errors  = (p,) vector, remaining lifetime labor supply Euler
+                errors
+    b_args    = length 3 tuple, args to pass into hh.get_b_errors()
+    b_errors  = (p-1,) vector, remaining lifetime savings Euler errors
+    bn_errors = (2p-1,) vector, remaining lifetime savings and labor
+                supply Euler errors
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: bn_errors
+    --------------------------------------------------------------------
+    '''
+    (rpath, wpath, b_init, p, beta, sigma, l_tilde, chi_n_vec, b_ellip,
+        upsilon, diff) = args
+    b_sp1_vec = np.append(bn_vec[:p - 1], 0.0)
+    n_vec = bn_vec[p - 1:]
+    b_s_vec = np.append(b_init, b_sp1_vec[:-1])
+    c_vec = get_cons(rpath, wpath, b_s_vec, b_sp1_vec, n_vec)
+    n_args = (wpath, sigma, l_tilde, chi_n_vec, b_ellip, upsilon, diff,
+              c_vec)
+    n_errors = get_n_errors(n_vec, *n_args)
+    b_args = (rpath[1:p], beta, sigma, diff)
+    b_errors = get_b_errors(c_vec, *b_args)
+    bn_errors = np.hstack((b_errors, n_errors))
+
+    return bn_errors

--- a/DeBacker_Evans_simple/utilities.py
+++ b/DeBacker_Evans_simple/utilities.py
@@ -1,0 +1,108 @@
+'''
+------------------------------------------------------------------------
+This module contains utility functions that do not naturally fit with
+any of the other modules.
+
+This Python module defines the following function(s):
+    print_time()
+    compare_args()
+------------------------------------------------------------------------
+'''
+# Import packages
+import numpy as np
+
+'''
+------------------------------------------------------------------------
+    Functions
+------------------------------------------------------------------------
+'''
+
+
+def print_time(seconds, type):
+    '''
+    --------------------------------------------------------------------
+    Takes a total amount of time in seconds and prints it in terms of
+    more readable units (days, hours, minutes, seconds)
+    --------------------------------------------------------------------
+    INPUTS:
+    seconds = scalar > 0, total amount of seconds
+    type    = string, either "SS" or "TPI"
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    secs = scalar > 0, remainder number of seconds
+    mins = integer >= 1, remainder number of minutes
+    hrs  = integer >= 1, remainder number of hours
+    days = integer >= 1, number of days
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: Nothing
+    --------------------------------------------------------------------
+    '''
+    if seconds < 60:  # seconds
+        secs = round(seconds, 4)
+        print(type + ' computation time: ' + str(secs) + ' sec')
+    elif seconds >= 60 and seconds < 3600:  # minutes
+        mins = int(seconds / 60)
+        secs = round(((seconds / 60) - mins) * 60, 1)
+        print(type + ' computation time: ' + str(mins) + ' min, ' +
+              str(secs) + ' sec')
+    elif seconds >= 3600 and seconds < 86400:  # hours
+        hrs = int(seconds / 3600)
+        mins = int(((seconds / 3600) - hrs) * 60)
+        secs = round(((seconds / 60) - hrs * 60 - mins) * 60, 1)
+        print(type + ' computation time: ' + str(hrs) + ' hrs, ' +
+              str(mins) + ' min, ' + str(secs) + ' sec')
+    elif seconds >= 86400:  # days
+        days = int(seconds / 86400)
+        hrs = int(((seconds / 86400) - days) * 24)
+        mins = int(((seconds / 3600) - days * 24 - hrs) * 60)
+        secs = round(
+            ((seconds / 60) - days * 24 * 60 - hrs * 60 - mins) * 60, 1)
+        print(type + ' computation time: ' + str(days) + ' days, ' +
+              str(hrs) + ' hrs, ' + str(mins) + ' min, ' +
+              str(secs) + ' sec')
+
+
+def compare_args(contnr1, contnr2):
+    '''
+    --------------------------------------------------------------------
+    Determine whether the contents of two tuples are equal
+    --------------------------------------------------------------------
+    INPUTS:
+    contnr1 = length n tuple
+    contnr2 = length n tuple
+
+    OTHER FUNCTIONS AND FILES CALLED BY THIS FUNCTION: None
+
+    OBJECTS CREATED WITHIN FUNCTION:
+    len1     = integer >= 1, number of elements in contnr1
+    len2     = integer >= 1, number of elements in contnr2
+    err_msg  = string, error message
+    same_vec = (len1,) boolean vector, =True for elements in contnr1 and
+               contnr2 that are the same
+    elem     = integer >= 0, element number in contnr1
+    same = boolean, =True if all elements of contnr1 and contnr2 are
+           equal
+
+    FILES CREATED BY THIS FUNCTION: None
+
+    RETURNS: same
+    --------------------------------------------------------------------
+    '''
+    len1 = len(contnr1)
+    len2 = len(contnr2)
+    if not len1 == len2:
+        err_msg = ('ERROR, compare_args(): Two tuples have different ' +
+                   'lengths')
+        print(err_msg)
+        same = False
+    else:
+        same_vec = np.zeros(len1, dtype=bool)
+        for elem in range(len1):
+            same_vec[elem] = np.min(contnr1[elem] == contnr2[elem])
+        same = np.min(same_vec)
+
+    return same


### PR DESCRIPTION
This PR adds code for solving the simple, representative agent model from [Chapter 4 of DeBacker and Evans](https://github.com/OpenRG/WB-India/blob/master/Chapters/OGtext_ch04.pdf).

The idea would be to take this as a starting off point and replace the `household.py` module and some of the functions in `aggregates.py`,`SS.py`, and `TPI.py` with versions that allow you to solve for the household under stochastic income shocks.

Use the income shock process from the Conesa and Krueger replication in this repo, but otherwise use parameters from this newly added code.

Essentially, you can think about  HH sol'n + aggregation -> K, L, which is then used put into the firm problem to update the "outer loop" of the GE solution.  What we'd like to do is replace the (HH sol'n + aggregation) parts with new versions that solve the stochastic problem, but return in the same way, aggregate K and L.

cc @rickecon