### PR TITLE
Add environment and workflow files

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,63 @@
+name: Build and test
+on:
+  push:
+    paths:
+      - '**.yml'
+      - '**.toml'
+      - '**.ini'
+      - '**.py'
+      - '**.json'
+      - '**.csv'
+      - '**.pkl'
+      - '**.pbz2'
+  pull_request:
+    paths:
+      - '**.yml'
+      - '**.toml'
+      - '**.ini'
+      - '**.py'
+      - '**.json'
+      - '**.csv'
+      - '**.pkl'
+      - '**.pbz2'
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Miniconda using Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: "latest"
+          auto-update-conda: true
+          activate-environment: hh-dev
+          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+      - name: Build
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+      - name: Test
+        shell: bash -l {0}
+        working-directory: ./
+        run: |
+          python -m pytest -m "not local" --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'john-p-ryan/computation_2024')
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/check_black.yml
+++ b/.github/workflows/check_black.yml
@@ -1,0 +1,15 @@
+
+name: Check Black formatting
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        with:
+          options: "-l 79 --check"
+          src: "."

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+name: hh-dev
+channels:
+- conda-forge
+dependencies:
+- python>=3.7.7, <3.13
+- numpy
+- ipython
+- scipy>=1.7.1
+- pandas>=1.2.5
+- numba
+- matplotlib
+- dask>=2.30.0
+- dask-core>=2.30.0
+- distributed>=2.30.1
+- paramtools>=0.20.0
+- jupyter
+- pytest>=6.0
+- pytest-cov
+- pytest-xdist
+- pylint
+- coverage
+- requests
+- black>=24.1.1
+- pip
+- pip:
+  - pygam

--- a/environment.yml
+++ b/environment.yml
@@ -24,3 +24,4 @@ dependencies:
 - pip
 - pip:
   - pygam
+  - ogcore


### PR DESCRIPTION
This PR adds:
1. An `environment.yml` file that can be used to create a `hh-dev` virtual environment to do the development in the repo in. This will ensure replicability across users.
2. Some workflow files to (a) make sure we use good code formatting (`black`) and (b) to run unit tests and code coverage (those tests are yet to be added).